### PR TITLE
Release v0.4.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,82 +1,165 @@
-🛠 La Stack Technique Confirmée
-- Langage : Rust (Edition 2021)
-- TUI : ratatui + crossterm (pour le support souris/clavier)
-- SSH : Handover via `exec` (commande système `ssh`) pour remplacer le processus courant
-- Config : serde + serde_yaml
-- Thème : Crate `catppuccin` (Flavor Mocha)
-- Terminal : Pas de gestion PTY interne, le handover laisse `ssh` gérer le terminal
+# Sushi — Instructions pour l'agent de développement
 
-📁 Structure du Projet (Workspace)
-L'agent devra suivre cette organisation pour séparer les responsabilités :
+> Toute la documentation (README, CHANGELOG, commentaires publics) est en **anglais**.
+> Les instructions de développement et les commentaires privés peuvent être en **français** à usage interne.
+> Les commits doivent être en anglais, mais les branches peuvent être nommées en français (ex: `feature/écran-erreur-tui`).
+> Les commits doivent respecter la convention [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+> On est en TDD — écris les tests avant d'implémenter la fonctionnalité.
+> Les PR doivent être rédigées en anglais, mais les titres peuvent être en français (ex: "Écran d'erreur in-TUI").
+> Ce fichier d'instructions est en français à usage interne.
+> On utilise le tutoiement pour une communication directe et informelle avec l'agent de développement.
+> Les instructions sont organisées en sections : Stack technique, Structure du projet, Schéma de configuration YAML, Patterns architecturaux, Modes de connexion SSH, Raccourcis clavier, Tests, Fonctionnalités implémentées et restantes.
 
-```Plaintext
+---
+
+## 🛠 Stack Technique
+
+| Composant | Crate / outil | Version |
+|-----------|--------------|---------|
+| Langage | Rust | Edition **2024** |
+| TUI | `ratatui` + `crossterm` | 0.30.0 / 0.29.0 |
+| SSH | `exec()` système — pas de PTY interne | — |
+| Config | `serde` + `serde_yaml` | — |
+| Thème | `catppuccin` (4 flavors configurables) | 2.6.0 |
+| CLI | `clap` (derive) | 4 |
+| Presse-papiers | `arboard` | 3 |
+| Persistance | `serde_json` | 1 |
+| Expansion `~` | `shellexpand` | 3 |
+| Erreurs | `anyhow` + `thiserror` | — |
+
+> `portable-pty = "0.9.0"` est présent dans `Cargo.toml` mais **non utilisé**.
+> À retirer ou exploiter dans une prochaine itération (item 5).
+
+---
+
+## 📁 Structure du Projet
+
+```
 sushi/
 ├── src/
-│   ├── main.rs          # Point d'entrée, gestion du panic hook
-│   ├── app.rs           # Logique de l'état de l'application (Tabs, Filtres)
-│   ├── config.rs        # Parsing YAML et mapping des serveurs
-│   ├── ui/              # Composants Ratatui (Tabs, Tree, SearchBar)
+│   ├── lib.rs           # Exports publics des modules
+│   ├── main.rs          # Point d'entrée : CLI clap, boucle événements, handover SSH
+│   ├── app.rs           # État de l'application (App, AppMode, ConfigItem, cache dirty)
+│   ├── config.rs        # Parsing YAML, ConnectionMode, ThemeVariant, ResolvedServer
+│   ├── state.rs         # Persistance ~/.sushi_state.json (groupes développés)
+│   ├── ui/
+│   │   ├── mod.rs       # Rendu ratatui complet (draw, draw_details, draw_error_overlay)
+│   │   ├── theme.rs     # Statics Catppuccin (LATTE/FRAPPÉ/MACCHIATO/MOCHA), get_theme()
+│   │   └── widgets/     # Widgets personnalisés (réservé extension future)
+│   ├── ssh/
 │   │   ├── mod.rs
-│   │   ├── theme.rs     # Définition des couleurs Catppuccin
-│   │   └── widgets/     # Widgets personnalisés (Arborescence)
-│   ├── ssh/             # Logique de connexion et gestion du PTY
-│   └── handlers/        # Gestion des événements (Clavier/Souris)
-└── tests/               # Tests d'intégration (TDD)
-```
-📝 Schéma de Configuration YAML
-Voici le modèle de données que l'agent doit valider (gestion de la profondeur 1 à 3) :
-
-```YAML
-# sushi.yaml
-defaults:
-  user: "default_user"
-  ssh_key: "~/.ssh/id_rsa"
-  # Surcharge globale possible pour le mode Rebond ou Bastion
-  jump_host: "gateway.corp"
-  jump_user: "gatekeeper"
-  bastion_host: "bastion.corp"
-  bastion_user: "root"
-  bastion_template: "{target_user}@%n:SSH:{bastion_user}"
-
-groups:
-  - name: "Projet Alpha"
-    user: "dev_user"  # Surcharge le global pour tout le groupe
-    environments:
-      - name: "Production"
-        ssh_key: "~/.ssh/prod_key" # Surcharge pour cet environnement uniquement
-        servers:
-          - name: "web-01"
-            host: "10.0.0.1"
-            # jump_host hérité
-          - name: "db-01"
-            host: "10.0.0.2"
-            user: "postgres" # Surcharge spécifique au serveur
-            # Résultat : user="postgres", key="prod_key"
-
+│   │   └── client.rs    # build_ssh_args() (pure, testable) + connect() (exec)
+│   └── handlers/
+│       └── mod.rs       # handle_mouse_event(), get_layout(), is_in_rect()
+├── examples/
+│   └── full_config.yaml # Référence complète de toutes les clés YAML
+├── tests/
+│   ├── parse_full_config.rs
+│   └── fixtures/        # YAML de fixtures pour les tests d'intégration
+├── CHANGELOG.md         # Keep a Changelog, anglais
+└── README.md
 ```
 
-## Nouvelles Fonctionnalités Requises
+---
 
-1. **Modes de Connexion (Tabs)**
-   - 3 Onglets sélectionnables (Tab ou Clic Souris) : Direct, Rebond (ProxyJump), Bastion.
-   - **Direct** : `ssh -p <port> <user>@<host>`
-   - **Rebond** : `ssh -J <jump_user>@<jump_host> <user>@<host>`
-   - **Bastion** : `ssh -l "<target_user>@<target_host>:SSH:<bastion_user>" <bastion_host>`
+## 📝 Schéma de Configuration YAML
 
-2. **Comportement Handover**
-   - Sushi doit restaurer le terminal et invoquer `exec()` pour remplacer son processus par `ssh`.
-   - `Ctrl+D` ou `exit` depuis la session SSH ferme complètement l'application (pas de retour au menu).
-   - Ignorer impérativement `~/.ssh/config` (`-F /dev/null`).
+Profondeur 1 à 3 : `defaults` → groupe → environnement → serveur.
+Référence complète : [`examples/full_config.yaml`](../examples/full_config.yaml)
 
-3. **Navigation Souris**
-   - Clic simple : Sélectionner un serveur.
-   - Double-clic : Lancer la connexion.
-   - Clic sur les onglets : Changer de mode.
+### Héritage (du moins prioritaire au plus prioritaire)
+```
+defaults → groupe → environnement → serveur
+```
+Chaque niveau surcharge : `user`, `port`, `ssh_key`, `ssh_options`,
+`default_mode`, `jump_host`, `jump_user`, `bastion_host`, `bastion_user`, `bastion_template`.
 
-4. **Fichier de configuration YAML**
-   - validation stricte du schéma (profondeur 1 à 3).
-   - support des variables d'environnement (ex: `~/.ssh/id_rsa`).
-   - gestion des héritages et surcharges (global → groupe → environnement → serveur).
-   - gestion des options ssh globales et spécifiques pour chaque mode (ex: `jump_host`, `bastion_template`).
-   - utilise les fichiers YAML situés dans tests/fixtures/ pour valider le comportement du parser.
-   - le fichier exemple `examples/full_config.yaml` doit être utilisé comme référence pour les tests de parsing et de validation.
+### `use_system_ssh_config` (dans `defaults`)
+- `false` (défaut) : passe `-F /dev/null` à SSH → ignore `~/.ssh/config`.
+- `true` : n'ajoute pas `-F /dev/null` → ControlMaster, aliases et identités `~/.ssh/config` sont honorés.
+
+---
+
+## 🏗 Patterns Architecturaux
+
+### `ConnectionMode` enum
+Remplace les chaînes magiques et l'index `usize`. Sérialisé/désérialisé en YAML (`lowercase`).
+Expose `index()`, `from_index()`, `next()`. Tab UI sélectionne Direct / Jump / Bastion.
+
+### `AppMode` enum
+`Normal` ou `Error(String)`. Quand `Error(msg)` est actif, un overlay rouge centré est affiché.
+Enter / Esc / q ferment l'overlay et reviennent à `Normal`.
+
+### Cache `items_dirty`
+`get_visible_items()` retourne `&[ConfigItem]` depuis un cache.
+Le flag `items_dirty` est levé uniquement quand la config, la recherche ou l'état d'expansion change.
+
+### `ResolvedServer`
+Struct plate issue de la résolution de l'héritage YAML. Tous les champs sont fusionnés.
+C'est ce type qui est passé à `build_ssh_args()` et affiché dans le panneau détail.
+
+### Handover SSH
+`connect()` dans `ssh/client.rs` appelle `Command::new("ssh").args(…).exec()` (trait `CommandExt`).
+Le processus sushi est **remplacé** par ssh — il n'y a pas de retour au menu après `exit` ou `Ctrl+D`.
+
+---
+
+## 🖥 Modes de Connexion SSH
+
+| Mode | Commande générée |
+|------|-----------------|
+| **Direct** | `ssh [-F /dev/null] [-v] [-p PORT] [-i KEY] [-o OPT] user@host` |
+| **Jump** | `ssh [-F /dev/null] [-v] -J jump_user@jump_host [-i KEY] user@host` |
+| **Bastion** | `ssh [-F /dev/null] [-v] -l "<bastion_template>" [-p PORT] bastion_host` |
+
+Le template bastion supporte : `{target_user}`, `{target_host}`, `{bastion_user}`, `%n`.
+
+---
+
+## ⌨️ Raccourcis Clavier (mode Normal)
+
+| Touche | Action |
+|--------|--------|
+| `↑` / `↓` | Naviguer dans la liste |
+| `Enter` | Connexion SSH (mode actif) |
+| `Space` | Développer / replier un groupe |
+| `/` | Entrer en mode recherche |
+| `Ctrl+U` | Vider la recherche (mode recherche) |
+| `Esc` | Quitter la recherche / fermer l'overlay erreur |
+| `Tab` | Passer au mode de connexion suivant |
+| `1` / `2` / `3` | Sélectionner Direct / Jump / Bastion |
+| `v` | Activer/désactiver le mode verbeux SSH |
+| `y` | Copier la commande SSH dans le presse-papiers |
+| `q` / `Ctrl+C` | Quitter |
+
+---
+
+## 🧪 Tests
+
+- **22 tests** au total, 0 échec — `cargo test`
+- `tests/parse_full_config.rs` : intégration, parsing YAML complet.
+- `src/ssh/client.rs` : 15 tests unitaires `build_ssh_args()` (3 modes × normaux + erreurs + edge cases).
+- `tests/fixtures/` : fichiers YAML de référence.
+
+---
+
+## ✅ Fonctionnalités Implémentées (v0.4.0)
+
+- [x] `ConnectionMode` enum typé (remplace les chaînes)
+- [x] CLI `clap` : `--config`, `--direct`, `--rebond`, `--bastion`, `--user`, `--port`, `--key`, `--verbose`
+- [x] `use_system_ssh_config` dans `defaults`
+- [x] Copie commande SSH dans le presse-papiers (`y`) via `arboard`
+- [x] `Ctrl+U` pour vider la recherche
+- [x] Persistance de l'état d'expansion (`~/.sushi_state.json`)
+- [x] Écran d'erreur in-TUI (`AppMode::Error`)
+- [x] Thème Catppuccin configurable (`latte` / `frappe` / `macchiato` / `mocha`)
+- [x] Panneau détail enrichi : port (jaune si ≠ 22), mode, jump host, bastion host
+- [x] `examples/full_config.yaml` documenté
+- [x] `build_ssh_args()` extraite comme fonction pure testable
+- [x] Cache `items_dirty` pour `get_visible_items()`
+- [x] `App::new()` retourne `Result<Self, ConfigError>`
+
+## 🔲 Fonctionnalités Restantes
+
+- [ ] **Item 5** : Retirer `portable-pty` de `Cargo.toml` (dépendance inutilisée) ou l'exploiter pour une gestion PTY interne.
+- [ ] **Item 10** : Multi-sauts SSH — `rebond: Option<Vec<JumpConfig>>` dans la config, construire `-J user1@h1,user2@h2` dans `build_ssh_args()`.

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -21,7 +21,7 @@ Liste des améliorations à implémenter une par une.
   - Ajouter un champ `cached_items: Vec<ConfigItem>` et un flag `dirty: bool`.
   - Recalculer uniquement quand la config, la recherche ou l'état d'expansion change.
 
-- [ ] **4. Remonter l'erreur de `config.resolve()` dans `App::new()`**
+- [x] **4. Remonter l'erreur de `config.resolve()` dans `App::new()`**
   - Fichier : `src/app.rs`
   - Changer la signature en `App::new(config: Config) -> Result<Self, ConfigError>` pour ne plus avaler les erreurs silencieusement avec `unwrap_or_default()`.
 

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -84,7 +84,7 @@ Liste des améliorations à implémenter une par une.
 
 ## Tests & maintenabilité
 
-- [ ] **15. Tests unitaires pour `ssh/client.rs`**
+- [x] **15. Tests unitaires pour `ssh/client.rs`**
   - Fichier : `src/ssh/client.rs`
   - Extraire la construction de la commande dans `build_ssh_args(server, mode, verbose) -> Vec<String>`.
   - Écrire des tests couvrant les 3 modes et les cas d'erreur (jump_host vide, bastion_host vide).

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -45,7 +45,7 @@ Liste des améliorations à implémenter une par une.
   - Ajouter un champ `use_system_ssh_config: bool` dans `Defaults` (défaut `false`).
   - Quand `true`, ne pas passer `-F /dev/null` afin de respecter `~/.ssh/config` (ControlMaster, aliases, clés…).
 
-- [ ] **8. Raccourci `Ctrl+U` pour vider la recherche**
+- [x] **8. Raccourci `Ctrl+U` pour vider la recherche**
   - Fichier : `src/main.rs`
   - En mode recherche, capturer `KeyCode::Char('u')` + `KeyModifiers::CONTROL` pour effacer `search_query` en entier.
 

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -34,7 +34,7 @@ Liste des améliorations à implémenter une par une.
 
 ## Fonctionnalités
 
-- [ ] **6. Argument CLI `--config <path>`**
+- [x] **6. Argument CLI `--config <path>`**
   - Fichier : `src/main.rs`
   - Ajouter `clap` en dépendance et exposer `--config`, `--version`, `--help`.
   - Permet de gérer plusieurs profils / contextes (perso, pro, client…).

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -1,0 +1,115 @@
+# Roadmap post-v0.3.0
+
+Liste des améliorations à implémenter une par une.
+
+---
+
+## Robustesse & qualité du code
+
+- [ ] **1. `ConnectionMode` en enum**
+  - Fichiers : `src/app.rs`, `src/main.rs`, `src/ssh/client.rs`
+  - Remplacer `connection_mode: usize` (valeurs magiques 0/1/2) par un enum `ConnectionMode { Direct, Jump, Bastion }`.
+  - Élimine les risques de valeur hors-borne et rend le `match` exhaustif.
+
+- [ ] **2. `mode: Option<String>` → enum serde dans la config**
+  - Fichier : `src/config.rs`
+  - Créer `enum ConnectionModeCfg { Direct, Jump, Bastion }` avec `#[serde(rename_all = "lowercase")]`.
+  - Une faute de frappe dans le YAML sera rejetée à la désérialisation au lieu de tomber silencieusement en mode `"direct"`.
+
+- [ ] **3. Mise en cache de `get_visible_items()`**
+  - Fichier : `src/app.rs`
+  - Ajouter un champ `cached_items: Vec<ConfigItem>` et un flag `dirty: bool`.
+  - Recalculer uniquement quand la config, la recherche ou l'état d'expansion change.
+
+- [ ] **4. Remonter l'erreur de `config.resolve()` dans `App::new()`**
+  - Fichier : `src/app.rs`
+  - Changer la signature en `App::new(config: Config) -> Result<Self, ConfigError>` pour ne plus avaler les erreurs silencieusement avec `unwrap_or_default()`.
+
+- [ ] **5. Supprimer ou exploiter la dépendance `portable-pty`**
+  - Fichier : `Cargo.toml`
+  - Si non utilisée : la retirer.
+  - Si prévue : implémenter l'ouverture du terminal intégré dans la TUI (session SSH inline).
+
+---
+
+## Fonctionnalités
+
+- [ ] **6. Argument CLI `--config <path>`**
+  - Fichier : `src/main.rs`
+  - Ajouter `clap` en dépendance et exposer `--config`, `--version`, `--help`.
+  - Permet de gérer plusieurs profils / contextes (perso, pro, client…).
+
+- [ ] **7. Rendre `-F /dev/null` optionnel**
+  - Fichier : `src/ssh/client.rs`
+  - Ajouter un champ `use_system_ssh_config: bool` dans `Defaults` (défaut `false`).
+  - Quand `true`, ne pas passer `-F /dev/null` afin de respecter `~/.ssh/config` (ControlMaster, aliases, clés…).
+
+- [ ] **8. Raccourci `Ctrl+U` pour vider la recherche**
+  - Fichier : `src/main.rs`
+  - En mode recherche, capturer `KeyCode::Char('u')` + `KeyModifiers::CONTROL` pour effacer `search_query` en entier.
+
+- [ ] **9. Copier la commande SSH dans le presse-papiers**
+  - Fichiers : `src/main.rs`, `src/ssh/client.rs`
+  - Raccourci `y` sur un serveur sélectionné.
+  - Extraire la construction de la commande SSH en une fonction `build_command()` (sans `exec`), puis écrire dans le presse-papiers (crate `arboard` ou appel `xclip`/`pbcopy`).
+
+- [ ] **10. Multi-sauts SSH (ProxyJump chaîné)**
+  - Fichiers : `src/config.rs`, `src/ssh/client.rs`
+  - Changer `rebond: Option<JumpConfig>` en `rebond: Option<Vec<JumpConfig>>`.
+  - Construire la chaîne `-J user1@host1,user2@host2` dans `client.rs`.
+
+- [ ] **11. Persistance de l'état d'expansion**
+  - Fichier : `src/app.rs`, nouveau module `src/state.rs`
+  - Sauvegarder `expanded_items: HashSet<String>` dans `~/.sushi_state.json` (serde_json) à la fermeture, restaurer au démarrage.
+
+---
+
+## UX / Interface
+
+- [ ] **12. Écran d'erreur in-TUI**
+  - Fichier : `src/main.rs`, `src/ui/mod.rs`
+  - Ajouter un variant `AppState::Error(String)` et afficher un panneau d'erreur centré dans la TUI au lieu de quitter brutalement avec `eprintln!`.
+
+- [ ] **13. Afficher le port effectif dans le panneau détail**
+  - Fichier : `src/ui/mod.rs` (`draw_details`)
+  - Vérifier que le port résolu (issu de `ResolvedServer.port`) est bien rendu visible, en particulier quand il diffère de 22.
+
+- [ ] **14. Thème configurable (variantes Catppuccin)**
+  - Fichiers : `src/config.rs`, `src/ui/theme.rs`
+  - Ajouter `theme: Option<String>` dans `Defaults` (`"latte"`, `"frappe"`, `"macchiato"`, `"mocha"`).
+  - Charger la palette correspondante depuis la crate `catppuccin` déjà présente.
+
+---
+
+## Tests & maintenabilité
+
+- [ ] **15. Tests unitaires pour `ssh/client.rs`**
+  - Fichier : `src/ssh/client.rs`
+  - Extraire la construction de la commande dans `build_ssh_args(server, mode, verbose) -> Vec<String>`.
+  - Écrire des tests couvrant les 3 modes et les cas d'erreur (jump_host vide, bastion_host vide).
+
+- [ ] **16. Ajouter un `CHANGELOG.md`**
+  - Fichier : `CHANGELOG.md` (racine du projet)
+  - Format [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/) avec les entrées `[0.3.0]`, `[0.2.0]`, etc.
+  - Documenter les changements futurs dans `[Unreleased]` au fil des PR.
+
+---
+
+## Ordre d'implémentation suggéré
+
+1. → **2** (enum config, sécurité de base)
+2. → **1** (enum ConnectionMode, refactor propre)
+3. → **6** (CLI args, clap)
+4. → **7** (respect de ~/.ssh/config)
+5. → **15** (tests client SSH)
+6. → **4** (propagation d'erreurs)
+7. → **9** (copie presse-papiers)
+8. → **8** (Ctrl+U)
+9. → **3** (cache visible items)
+10. → **11** (persistance expansion)
+11. → **12** (écran erreur TUI)
+12. → **14** (thèmes)
+13. → **10** (multi-jump)
+14. → **5** (portable-pty / terminal intégré)
+15. → **13** (port dans détails)
+16. → **16** (CHANGELOG)

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -67,7 +67,7 @@ Liste des améliorations à implémenter une par une.
 
 ## UX / Interface
 
-- [ ] **12. Écran d'erreur in-TUI**
+- [x] **12. Écran d'erreur in-TUI**
   - Fichier : `src/main.rs`, `src/ui/mod.rs`
   - Ajouter un variant `AppState::Error(String)` et afficher un panneau d'erreur centré dans la TUI au lieu de quitter brutalement avec `eprintln!`.
 

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -16,7 +16,7 @@ Liste des améliorations à implémenter une par une.
   - Créer `enum ConnectionModeCfg { Direct, Jump, Bastion }` avec `#[serde(rename_all = "lowercase")]`.
   - Une faute de frappe dans le YAML sera rejetée à la désérialisation au lieu de tomber silencieusement en mode `"direct"`.
 
-- [ ] **3. Mise en cache de `get_visible_items()`**
+- [x] **3. Mise en cache de `get_visible_items()`**
   - Fichier : `src/app.rs`
   - Ajouter un champ `cached_items: Vec<ConfigItem>` et un flag `dirty: bool`.
   - Recalculer uniquement quand la config, la recherche ou l'état d'expansion change.

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -40,7 +40,7 @@ Liste des améliorations à implémenter une par une.
   - Permet de gérer plusieurs profils / contextes (perso, pro, client…).
   - exposer `--direct`, `--rebond` et `--bastion` suivi d'un host pour initier une connexion directe sans passer par l'ui  
 
-- [ ] **7. Rendre `-F /dev/null` optionnel**
+- [x] **7. Rendre `-F /dev/null` optionnel**
   - Fichier : `src/ssh/client.rs`
   - Ajouter un champ `use_system_ssh_config: bool` dans `Defaults` (défaut `false`).
   - Quand `true`, ne pas passer `-F /dev/null` afin de respecter `~/.ssh/config` (ControlMaster, aliases, clés…).

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -11,7 +11,7 @@ Liste des améliorations à implémenter une par une.
   - Remplacer `connection_mode: usize` (valeurs magiques 0/1/2) par un enum `ConnectionMode { Direct, Jump, Bastion }`.
   - Élimine les risques de valeur hors-borne et rend le `match` exhaustif.
 
-- [ ] **2. `mode: Option<String>` → enum serde dans la config**
+- [x] **2. `mode: Option<String>` → enum serde dans la config**
   - Fichier : `src/config.rs`
   - Créer `enum ConnectionModeCfg { Direct, Jump, Bastion }` avec `#[serde(rename_all = "lowercase")]`.
   - Une faute de frappe dans le YAML sera rejetée à la désérialisation au lieu de tomber silencieusement en mode `"direct"`.

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -59,7 +59,7 @@ Liste des améliorations à implémenter une par une.
   - Changer `rebond: Option<JumpConfig>` en `rebond: Option<Vec<JumpConfig>>`.
   - Construire la chaîne `-J user1@host1,user2@host2` dans `client.rs`.
 
-- [ ] **11. Persistance de l'état d'expansion**
+- [x] **11. Persistance de l'état d'expansion**
   - Fichier : `src/app.rs`, nouveau module `src/state.rs`
   - Sauvegarder `expanded_items: HashSet<String>` dans `~/.sushi_state.json` (serde_json) à la fermeture, restaurer au démarrage.
 

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -6,7 +6,7 @@ Liste des améliorations à implémenter une par une.
 
 ## Robustesse & qualité du code
 
-- [ ] **1. `ConnectionMode` en enum**
+- [x] **1. `ConnectionMode` en enum**
   - Fichiers : `src/app.rs`, `src/main.rs`, `src/ssh/client.rs`
   - Remplacer `connection_mode: usize` (valeurs magiques 0/1/2) par un enum `ConnectionMode { Direct, Jump, Bastion }`.
   - Élimine les risques de valeur hors-borne et rend le `match` exhaustif.
@@ -38,6 +38,7 @@ Liste des améliorations à implémenter une par une.
   - Fichier : `src/main.rs`
   - Ajouter `clap` en dépendance et exposer `--config`, `--version`, `--help`.
   - Permet de gérer plusieurs profils / contextes (perso, pro, client…).
+  - exposer `--direct`, `--rebond` et `--bastion` suivi d'un host pour initier une connexion directe sans passer par l'ui  
 
 - [ ] **7. Rendre `-F /dev/null` optionnel**
   - Fichier : `src/ssh/client.rs`

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -75,7 +75,7 @@ Liste des améliorations à implémenter une par une.
   - Fichier : `src/ui/mod.rs` (`draw_details`)
   - Vérifier que le port résolu (issu de `ResolvedServer.port`) est bien rendu visible, en particulier quand il diffère de 22.
 
-- [ ] **14. Thème configurable (variantes Catppuccin)**
+- [x] **14. Thème configurable (variantes Catppuccin)**
   - Fichiers : `src/config.rs`, `src/ui/theme.rs`
   - Ajouter `theme: Option<String>` dans `Defaults` (`"latte"`, `"frappe"`, `"macchiato"`, `"mocha"`).
   - Charger la palette correspondante depuis la crate `catppuccin` déjà présente.

--- a/.idea/roadmap-v0.4.0.md
+++ b/.idea/roadmap-v0.4.0.md
@@ -49,7 +49,7 @@ Liste des améliorations à implémenter une par une.
   - Fichier : `src/main.rs`
   - En mode recherche, capturer `KeyCode::Char('u')` + `KeyModifiers::CONTROL` pour effacer `search_query` en entier.
 
-- [ ] **9. Copier la commande SSH dans le presse-papiers**
+- [x] **9. Copier la commande SSH dans le presse-papiers**
   - Fichiers : `src/main.rs`, `src/ssh/client.rs`
   - Raccourci `y` sur un serveur sélectionné.
   - Extraire la construction de la commande SSH en une fonction `build_command()` (sans `exec`), puis écrire dans le presse-papiers (crate `arboard` ou appel `xclip`/`pbcopy`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+---
+
+## [Unreleased] — v0.4.0
+
+### Added
+- **`ConnectionMode` enum**: replaced `"direct"/"jump"/"bastion"` strings and the `usize` integer with a typed enum throughout the codebase (`config`, `app`, `client`, `handlers`, `ui`). Typos in YAML are now rejected at deserialization.
+- **CLI via `clap`**: `--config`, `--direct`, `--rebond`, `--bastion`, `--user`, `--port`, `--key`, `--verbose` flags. The `--direct/--rebond/--bastion` modes connect directly without launching the TUI.
+- **`use_system_ssh_config`**: new field in `defaults` (YAML). When `true`, `-F /dev/null` is omitted so `~/.ssh/config` is honored (ControlMaster, aliases, identity files…).
+- **Copy SSH command to clipboard** (`y`) via `arboard`. Feedback appears in green in the status bar for 3 seconds.
+- **`Ctrl+U`** to clear the search query while in search mode.
+- **Expansion state persistence** in `~/.sushi_state.json` (serde_json). Expanded groups/environments are restored on next startup.
+- **In-TUI error screen**: `AppMode::Error(String)` renders a centered popup with a rounded red border. Enter/Esc/q dismiss the overlay. SSH errors (missing host, etc.) are caught before connecting.
+- **Configurable Catppuccin theme**: `defaults.theme: latte | frappe | macchiato | mocha` in the YAML config. Default: `mocha`.
+- **Enriched detail pane**: now shows the effective port (highlighted in yellow when ≠ 22), connection mode, jump host, and bastion host when configured.
+- **`examples/full_config.yaml`**: fully documented reference file covering all 3 nesting levels (group → environment → server) and every available key.
+
+### Changed
+- `App::new()` now returns `Result<Self, ConfigError>` instead of silently swallowing errors with `unwrap_or_default()`.
+- `get_visible_items()` is cached with a `dirty` flag — recomputed only when the config, search query, or expansion state changes.
+- `build_ssh_args()` extracted as a pure, testable function from `connect()`.
+
+### Quality
+- 15 unit tests for `ssh/client.rs` (3 modes × normal cases + errors + edge cases).
+- 22 tests total (6 app/config + 1 integration + 15 SSH client), 0 failures.
+
+---
+
+## [0.3.0] — 2026-02-XX
+
+### Added
+- Verbose mode (`-v`) toggled with the `v` key in the TUI.
+- Search by host in addition to server name.
+- Fixed connection mode inheritance along the defaults → group → env → server chain.
+
+### Fixed
+- Rust edition corrected from `2026` to `2024`.
+
+---
+
+## [0.2.0] — v0.1.1
+
+### Added
+- ratatui TUI with a group/environment/server tree view.
+- SSH connection via `exec()` (process replacement).
+- Keyboard navigation (↑/↓, Tab, 1/2/3, Enter, Space, /).
+- Mouse click and double-click support.
+- 4-level configuration inheritance (defaults → group → environment → server).
+- Connection modes: Direct, Jump (ProxyJump), Bastion.
+- GitHub Actions CI/CD pipeline.
+
+---
+
+## [0.1.0]
+
+### Added
+- First working version: TUI SSH manager with YAML config file support.
+
+[Unreleased]: https://github.com/yatoub/sushi/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/yatoub/sushi/compare/v0.1.1...v0.3.0
+[0.2.0]: https://github.com/yatoub/sushi/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/yatoub/sushi/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +183,52 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -543,6 +639,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +883,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -1358,10 +1466,11 @@ dependencies = [
 
 [[package]]
 name = "sushi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "catppuccin",
+ "clap",
  "crossterm",
  "portable-pty",
  "ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "portable-pty",
  "ratatui",
  "serde",
+ "serde_json",
  "serde_yaml",
  "shellexpand",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +59,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +70,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -72,6 +78,26 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
 
 [[package]]
 name = "atomic"
@@ -141,6 +167,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "castaway"
@@ -225,6 +257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +338,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -408,7 +464,17 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
 ]
 
 [[package]]
@@ -445,8 +511,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "euclid"
@@ -474,6 +546,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +596,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -522,6 +633,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -558,6 +679,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -603,6 +735,20 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
 
 [[package]]
 name = "indexmap"
@@ -797,6 +943,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,7 +961,17 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -879,6 +1045,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1166,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1024,6 +1269,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1332,21 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1258,7 +1531,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1420,6 +1693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1748,7 @@ name = "sushi"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "catppuccin",
  "clap",
  "crossterm",
@@ -1513,7 +1793,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1617,6 +1897,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1830,6 +2124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,12 +2231,86 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winreg"
@@ -2036,7 +2410,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "sushi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.102"
+arboard = "3"
 catppuccin = "2.6.0"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sushi"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ crossterm = "0.29.0"
 portable-pty = "0.9.0"
 ratatui = { version = "0.30.0", features = ["crossterm"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 serde_yaml = "0.9"
 shellexpand = "3.1.2"
 thiserror = "2.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.102"
 catppuccin = "2.6.0"
+clap = { version = "4", features = ["derive"] }
 crossterm = "0.29.0"
 portable-pty = "0.9.0"
 ratatui = { version = "0.30.0", features = ["crossterm"] }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # 🍣 Sushi
 
-**Sushi** is a modern, terminal-based SSH connection manager written in Rust. It helps you organize your servers into groups and environments, handle complex connection scenarios (jumphosts, bastions), and connect quickly with a beautiful TUI.
-
-![Sushi TUI](https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/palette/mocha.png) 
-*(Note: Uses Catppuccin Mocha theme)*
+**Sushi** is a modern, terminal-based SSH connection manager written in Rust. It helps you organize your servers into groups and environments, handle complex connection scenarios (jumphosts, bastions), and connect quickly with a beautiful TUI with Catppuccin theme.
 
 ## ✨ Features
 
@@ -28,9 +25,12 @@
   - **Smart Expansion**: Auto-expands groups when searching.
 - **Interactive TUI**:
   - **Mouse Support**: Click to select, double-click to connect.
-  - **Beautiful UI**: Styled with the Catppuccin Mocha palette.
-  - **Verbose Mode**: Toggle SSH verbose output (`-v`) with a single keypress.
-  - **Detailed View**: SSH options displayed as a clean, readable list.
+  - **Configurable Theme**: Choose from four Catppuccin flavors — `latte`, `frappe`, `macchiato`, or `mocha` (default) via `defaults.theme` in your config.
+  - **Verbose Mode**: Toggle SSH verbose output with `v`.
+  - **Rich Detail Pane**: Shows port (highlighted when non-standard), connection mode, jump host, and bastion host.
+  - **Clipboard**: Copy the SSH command for any server with `y` (requires a running clipboard manager on Linux).
+- **State Persistence**: Expanded groups are saved to `~/.sushi_state.json` and restored on next launch.
+- **In-TUI Error Screen**: Connection errors are displayed as an overlay instead of crashing — press `Enter`/`Esc`/`q` to dismiss.
 - **Smart Sorting**: Automatically sorts groups and servers alphabetically.
 
 ## 🚀 Installation
@@ -61,6 +61,7 @@ defaults:
   user: "admin"
   ssh_key: "~/.ssh/id_ed25519"
   ssh_port: 22
+  theme: mocha  # latte | frappe | macchiato | mocha (default)
   ssh_options:
     - "StrictHostKeyChecking=no"
     - "UserKnownHostsFile=/dev/null"
@@ -115,6 +116,7 @@ groups:
 
 - **`defaults`**: Global settings applied to all servers unless overridden.
   - `mode`: Default connection mode (`direct`, `jump`, or `bastion`).
+  - `theme`: UI color theme — `latte`, `frappe`, `macchiato`, or `mocha` (default).
   - `rebond`: Jump host configuration (required when using `jump` mode).
   - `bastion`: Bastion configuration (required when using `bastion` mode).
   - `use_system_ssh_config`: Set to `true` to honour `~/.ssh/config` instead of passing `-F /dev/null`. Defaults to `false`.
@@ -141,7 +143,9 @@ groups:
 | `1` | Select **Direct** mode |
 | `2` | Select **Rebond** mode |
 | `3` | Select **Bastion** mode |
-| `Esc` | Cancel/clear search |
+| `Ctrl+U` | Clear search query (while in search mode) |
+| `y` | Copy SSH command to clipboard |
+| `Esc` | Cancel search / dismiss error overlay |
 
 ### Mouse Support
 
@@ -175,15 +179,21 @@ sushi --help
 
 ## 🎨 Theme & UI
 
-Sushi uses the **Catppuccin Mocha** color palette for a soothing and high-contrast look.
+Sushi uses the [Catppuccin](https://github.com/catppuccin/catppuccin) palette. Choose a flavor in your config:
 
-### Color Scheme
+```yaml
+defaults:
+  theme: mocha   # latte | frappe | macchiato | mocha (default)
+```
+
+### Color Scheme (Mocha)
 
 - **Blue**: Default borders
 - **Sapphire**: Active search border
 - **Green**: Successful search results, verbose mode active, environment headers
-- **Red**: No search results
-- **Sky**: Active connection mode tab
+- **Red**: No search results, error overlay border
+- **Sky**: Active connection mode tab, jump / bastion host in detail pane
+- **Yellow**: Port number when different from 22
 - **Mauve**: Group headers
 - **Surface2**: Selection background
 
@@ -192,7 +202,8 @@ Sushi uses the **Catppuccin Mocha** color palette for a soothing and high-contra
 - **Search Bar**: Dynamic title showing result count ("🔍 45 / 387 servers")
 - **Connection Modes**: Tab interface with visual highlight
 - **Verbose Toggle**: Checkbox indicator (☐/☑) with color feedback
-- **Server Details**: Clean list view for SSH options
+- **Detail Pane**: Port, mode, identity file, jump/bastion host, SSH options
+- **Error Overlay**: Centered popup for connection errors — press `Enter` to dismiss
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
   - **Mode Inheritance**: Connection mode inherits from defaults → group → environment → server.
 - **Configuration Inheritance**: Define defaults globally or at the group/environment level to avoid repetition.
   - Full cascading support for user, ssh_key, mode, port, options, and connection configs.
+  - `use_system_ssh_config`: opt in to respecting `~/.ssh/config` (ControlMaster, aliases…).
+- **CLI — connect without opening the TUI**:
+  - `--direct`, `--rebond`, `--bastion` `[user@]host[:port]` — instant SSH connection.
+  - `-u/--user`, `-p/--port`, `-k/--key` — override any SSH parameter.
+  - `-c/--config` — use an alternate configuration file.
+  - `-v/--verbose` — enable SSH verbose output.
 - **Advanced Search**:
   - **Multi-field Search**: Search by server name OR hostname.
   - **Live Results Counter**: See matching servers in real-time (e.g., "45 / 387 servers").
@@ -45,50 +51,65 @@ sudo cp target/release/sushi /usr/local/bin/
 
 ## ⚙️ Configuration
 
-Sushi looks for a configuration file at `~/.sushi.yml`.
+Sushi looks for a configuration file at `~/.sushi.yml`.  
+A fully annotated example covering every feature is available at [`examples/full_config.yaml`](examples/full_config.yaml).
 
 ### Example `~/.sushi.yml`
 
 ```yaml
 defaults:
   user: "admin"
-  ssh_key: "~/.ssh/id_rsa"
-  mode: "jump"  # Default connection mode for all servers
+  ssh_key: "~/.ssh/id_ed25519"
   ssh_port: 22
   ssh_options:
     - "StrictHostKeyChecking=no"
     - "UserKnownHostsFile=/dev/null"
+  # Set to true to honour ~/.ssh/config (ControlMaster, aliases, etc.)
+  use_system_ssh_config: false
   rebond:
-    host: "jumphost.example.com"
-    user: "jumpuser"
+    host: "jump.example.com"
+    user: "jump"
+  bastion:
+    host: "bastion.example.com"
+    user: "bastion"
 
 groups:
-  - name: "Production"
-    user: "prod_user" # Overrides default user
-    mode: "direct"    # Override mode for this group
+  # Level 3: Group → Environment → Server
+  - name: "Projet Alpha"
+    user: "dev"             # overrides default user for this group
     environments:
-      - name: "AWS"
-        mode: "bastion"  # Override mode for this environment
-        bastion:
-          host: "bastion.aws.example.com"
-          user: "ubuntu"
-          template: "{target_user}@%n:SSH:{bastion_user}"
+      - name: "Production"
         servers:
-          - name: "Web Server 01"
-            host: "10.0.1.5"
-            # Inherits bastion mode from environment
+          - name: "web-01"
+            host: "192.168.1.10"
+            mode: "direct"
+          - name: "db-01"
+            host: "192.168.1.11"  # inherits mode from defaults
+      - name: "Staging"
+        servers:
+          - name: "web-stg"
+            host: "192.168.1.20"
+            mode: "jump"          # override at server level
 
-  - name: "Staging"
+  # Level 2: Group → Server
+  - name: "Infrastructure"
     servers:
-      - name: "API Server"
-        host: "192.168.1.50"
-        # Uses defaults
+      - name: "proxmox-host"
+        host: "192.168.1.100"
+        mode: "direct"
+      - name: "internal-nas"
+        host: "192.168.1.200"
+        user: "root"
+        mode: "bastion"
 
-  # Single server at root
-  - name: "My VPS"
-    host: "vps.example.org"
-    user: "root"
+  # Level 1: Single server at root
+  - name: "Raspberry-Pi-Home"
+    host: "raspberrypi.local"
+    user: "pi"
+    mode: "direct"
 ```
+
+> See [`examples/full_config.yaml`](examples/full_config.yaml) for a complete reference with all options and inline comments.
 
 ### Configuration Breakdown
 
@@ -96,6 +117,7 @@ groups:
   - `mode`: Default connection mode (`direct`, `jump`, or `bastion`).
   - `rebond`: Jump host configuration (required when using `jump` mode).
   - `bastion`: Bastion configuration (required when using `bastion` mode).
+  - `use_system_ssh_config`: Set to `true` to honour `~/.ssh/config` instead of passing `-F /dev/null`. Defaults to `false`.
 - **`groups`**: The top-level hierarchy. Can contain `environments` or direct `servers`.
   - Can override any default setting including `mode`.
 - **`environments`**: A sub-grouping under a Group.
@@ -125,6 +147,31 @@ groups:
 
 - **Click**: Select server or change tab
 - **Double-click**: Connect to selected server
+
+## 🖥️ CLI Usage
+
+Sushi can connect directly without opening the TUI:
+
+```bash
+# Connect directly
+sushi --direct root@myserver
+sushi --direct admin@10.0.1.5:2222
+
+# Connect via jump host
+sushi --rebond root@192.168.1.50
+
+# Connect via bastion
+sushi --bastion web-01.prod.example.com
+
+# Override SSH parameters
+sushi --direct myserver.com --user deploy --port 2222 --key ~/.ssh/deploy_rsa
+
+# Use a custom config file
+sushi --config ~/work/.sushi.yml
+
+# Show all options
+sushi --help
+```
 
 ## 🎨 Theme & UI
 

--- a/examples/check_mode_inheritance.rs
+++ b/examples/check_mode_inheritance.rs
@@ -1,4 +1,4 @@
-use sushi::config::Config;
+use sushi::config::{Config, ConnectionMode};
 
 fn main() {
     let config_path = std::env::var("HOME").unwrap() + "/.sushi.yml";
@@ -26,15 +26,14 @@ fn main() {
                     println!("\n📊 Sample servers and their modes:");
                     for server in servers.iter().take(20) {
                         let mode = &server.default_mode;
-                        match mode.as_str() {
-                            "direct" => direct_count += 1,
-                            "jump" => jump_count += 1,
-                            "bastion" => bastion_count += 1,
-                            _ => {}
+                        match mode {
+                            ConnectionMode::Direct => direct_count += 1,
+                            ConnectionMode::Jump => jump_count += 1,
+                            ConnectionMode::Bastion => bastion_count += 1,
                         }
                         
                         println!("  - [{:8}] {}/{}/{}", 
-                            mode, 
+                            mode,
                             server.group_name, 
                             server.env_name, 
                             server.name
@@ -43,11 +42,10 @@ fn main() {
                     
                     // Count all modes
                     for server in servers.iter().skip(20) {
-                        match server.default_mode.as_str() {
-                            "direct" => direct_count += 1,
-                            "jump" => jump_count += 1,
-                            "bastion" => bastion_count += 1,
-                            _ => {}
+                        match server.default_mode {
+                            ConnectionMode::Direct => direct_count += 1,
+                            ConnectionMode::Jump => jump_count += 1,
+                            ConnectionMode::Bastion => bastion_count += 1,
                         }
                     }
                     

--- a/examples/full_config.yaml
+++ b/examples/full_config.yaml
@@ -11,6 +11,7 @@ defaults:
   ssh_options:
     - "StrictHostKeyChecking=no"
     - "UserKnownHostsFile=/dev/null"
+  use_system_ssh_config: false
   bastion:
     host: "bastion.example.com"
     user: "bastion"

--- a/examples/full_config.yaml
+++ b/examples/full_config.yaml
@@ -12,6 +12,8 @@ defaults:
     - "StrictHostKeyChecking=no"
     - "UserKnownHostsFile=/dev/null"
   use_system_ssh_config: false
+  # Thème Catppuccin : latte | frappe | macchiato | mocha (défaut)
+  theme: mocha
   bastion:
     host: "bastion.example.com"
     user: "bastion"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::time::Instant;
 use ratatui::widgets::ListState;
 use crate::config::{Config, ConfigError, ResolvedServer, ConfigEntry, ConnectionMode};
 
@@ -22,6 +23,9 @@ pub struct App {
     
     pub connection_mode: ConnectionMode,
     pub verbose_mode: bool,
+
+    /// Message temporaire affiché dans la barre de statut (texte, timestamp)
+    pub status_message: Option<(String, Instant)>,
 }
 
 impl App {
@@ -38,6 +42,7 @@ impl App {
             is_searching: false,
             connection_mode: ConnectionMode::Direct,
             verbose_mode: false,
+            status_message: None,
         };
         
         app.list_state.select(Some(0));
@@ -47,6 +52,11 @@ impl App {
         
         app.update_mode_from_selection();
         Ok(app)
+    }
+
+    /// Affiche un message temporaire dans la barre de statut.
+    pub fn set_status_message(&mut self, msg: impl Into<String>) {
+        self.status_message = Some((msg.into(), Instant::now()));
     }
 
     pub fn toggle_expansion(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::time::Instant;
 use ratatui::widgets::ListState;
 use crate::config::{Config, ConfigError, ResolvedServer, ConfigEntry, ConnectionMode};
+use crate::state;
 
 #[derive(Debug, Clone)]
 pub enum ConfigItem {
@@ -53,11 +54,20 @@ impl App {
         
         app.list_state.select(Some(0));
 
-        // Start collapsed by default
-        app.expanded_items.clear();
-        
+        // Restaure l'état d'expansion persistant
+        let saved = state::load_state();
+        app.expanded_items = saved.expanded_items;
+        app.items_dirty = true;
+
         app.update_mode_from_selection();
         Ok(app)
+    }
+
+    /// Retourne l'état persistable de l'application (pour la sauvegarde).
+    pub fn to_app_state(&self) -> crate::state::AppState {
+        crate::state::AppState {
+            expanded_items: self.expanded_items.clone(),
+        }
     }
 
     /// Affiche un message temporaire dans la barre de statut.

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,7 @@ pub struct App {
     pub search_query: String,
     pub is_searching: bool,
     
-    pub connection_mode: usize,
+    pub connection_mode: ConnectionMode,
     pub verbose_mode: bool,
 }
 
@@ -36,7 +36,7 @@ impl App {
             expanded_items: HashSet::new(),
             search_query: String::new(),
             is_searching: false,
-            connection_mode: 0,
+            connection_mode: ConnectionMode::Direct,
             verbose_mode: false,
         };
         
@@ -187,11 +187,7 @@ impl App {
         let items = self.get_visible_items();
         if let Some(item) = items.get(self.selected_index) {
             if let ConfigItem::Server(server) = item {
-                match server.default_mode {
-                    ConnectionMode::Jump => self.connection_mode = 1,
-                    ConnectionMode::Bastion => self.connection_mode = 2,
-                    ConnectionMode::Direct => self.connection_mode = 0,
-                }
+                self.connection_mode = server.default_mode;
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,10 @@ pub struct App {
 
     /// Message temporaire affiché dans la barre de statut (texte, timestamp)
     pub status_message: Option<(String, Instant)>,
+
+    /// Cache de la liste visible — recalculé seulement quand `items_dirty` est vrai.
+    cached_items: Vec<ConfigItem>,
+    items_dirty: bool,
 }
 
 impl App {
@@ -43,6 +47,8 @@ impl App {
             connection_mode: ConnectionMode::Direct,
             verbose_mode: false,
             status_message: None,
+            cached_items: Vec::new(),
+            items_dirty: true,
         };
         
         app.list_state.select(Some(0));
@@ -57,6 +63,12 @@ impl App {
     /// Affiche un message temporaire dans la barre de statut.
     pub fn set_status_message(&mut self, msg: impl Into<String>) {
         self.status_message = Some((msg.into(), Instant::now()));
+    }
+
+    /// Invalide le cache de la liste visible (à appeler après toute modification
+    /// de `search_query`, `expanded_items` ou `resolved_servers`).
+    pub fn invalidate_cache(&mut self) {
+        self.items_dirty = true;
     }
 
     pub fn toggle_expansion(&mut self) {
@@ -82,9 +94,18 @@ impl App {
                 _ => {}
             }
         }
+        self.items_dirty = true; // l'état d'expansion a changé
     }
 
-    pub fn get_visible_items(&self) -> Vec<ConfigItem> {
+    pub fn get_visible_items(&mut self) -> Vec<ConfigItem> {
+        if self.items_dirty {
+            self.cached_items = self.build_visible_items();
+            self.items_dirty = false;
+        }
+        self.cached_items.clone()
+    }
+
+    fn build_visible_items(&self) -> Vec<ConfigItem> {
         let mut items = Vec::new();
         
         for entry in &self.config.groups {
@@ -243,7 +264,7 @@ mod tests {
     #[test]
     fn test_initial_visibility() {
         let config = create_test_config();
-        let app = App::new(config).unwrap();
+        let mut app = App::new(config).unwrap();
         let items = app.get_visible_items();
         
         // Initially only the group header is visible (collapsed state)
@@ -295,6 +316,7 @@ mod tests {
         let mut app = App::new(config).unwrap();
         
         app.search_query = "S1".to_string();
+        app.invalidate_cache();
         let items = app.get_visible_items();
         
         // With search "S1":

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use ratatui::widgets::ListState;
-use crate::config::{Config, ResolvedServer, ConfigEntry};
+use crate::config::{Config, ResolvedServer, ConfigEntry, ConnectionMode};
 
 #[derive(Debug, Clone)]
 pub enum ConfigItem {
@@ -187,10 +187,10 @@ impl App {
         let items = self.get_visible_items();
         if let Some(item) = items.get(self.selected_index) {
             if let ConfigItem::Server(server) = item {
-                match server.default_mode.as_str() {
-                    "jump" => self.connection_mode = 1,
-                    "bastion" => self.connection_mode = 2,
-                    _ => self.connection_mode = 0, // "direct" or default
+                match server.default_mode {
+                    ConnectionMode::Jump => self.connection_mode = 1,
+                    ConnectionMode::Bastion => self.connection_mode = 2,
+                    ConnectionMode::Direct => self.connection_mode = 0,
                 }
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 use std::time::Instant;
 use ratatui::widgets::ListState;
-use crate::config::{Config, ConfigError, ResolvedServer, ConfigEntry, ConnectionMode};
+use crate::config::{Config, ConfigError, ResolvedServer, ConfigEntry, ConnectionMode, ThemeVariant};
 use crate::state;
+use crate::ui::theme::{Theme, get_theme};
 
 /// Mode courant de l'application.
 #[derive(Debug, Default, PartialEq)]
@@ -37,6 +38,9 @@ pub struct App {
     /// Mode courant (Normal ou Error).
     pub app_mode: AppMode,
 
+    /// Thème Catppuccin actif (résolu à l'initialisation depuis la config).
+    pub theme: &'static Theme,
+
     /// Message temporaire affiché dans la barre de statut (texte, timestamp)
     pub status_message: Option<(String, Instant)>,
 
@@ -48,6 +52,13 @@ pub struct App {
 impl App {
     pub fn new(config: Config) -> Result<Self, ConfigError> {
         let resolved = config.resolve()?;
+
+        // Résout le thème avant de déplacer config dans le struct
+        let theme_variant = config
+            .defaults
+            .as_ref()
+            .and_then(|d| d.theme)
+            .unwrap_or(ThemeVariant::Mocha);
         
         let mut app = Self {
             config,
@@ -60,6 +71,7 @@ impl App {
             connection_mode: ConnectionMode::Direct,
             verbose_mode: false,
             app_mode: AppMode::Normal,
+            theme: get_theme(theme_variant),
             status_message: None,
             cached_items: Vec::new(),
             items_dirty: true,

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,15 @@ use ratatui::widgets::ListState;
 use crate::config::{Config, ConfigError, ResolvedServer, ConfigEntry, ConnectionMode};
 use crate::state;
 
+/// Mode courant de l'application.
+#[derive(Debug, Default, PartialEq)]
+pub enum AppMode {
+    #[default]
+    Normal,
+    /// Affiche un panneau d'erreur bloquant jusqu'à la confirmation.
+    Error(String),
+}
+
 #[derive(Debug, Clone)]
 pub enum ConfigItem {
     Group(String), 
@@ -24,6 +33,9 @@ pub struct App {
     
     pub connection_mode: ConnectionMode,
     pub verbose_mode: bool,
+
+    /// Mode courant (Normal ou Error).
+    pub app_mode: AppMode,
 
     /// Message temporaire affiché dans la barre de statut (texte, timestamp)
     pub status_message: Option<(String, Instant)>,
@@ -47,6 +59,7 @@ impl App {
             is_searching: false,
             connection_mode: ConnectionMode::Direct,
             verbose_mode: false,
+            app_mode: AppMode::Normal,
             status_message: None,
             cached_items: Vec::new(),
             items_dirty: true,
@@ -73,6 +86,16 @@ impl App {
     /// Affiche un message temporaire dans la barre de statut.
     pub fn set_status_message(&mut self, msg: impl Into<String>) {
         self.status_message = Some((msg.into(), Instant::now()));
+    }
+
+    /// Passe en mode erreur avec le message donné.
+    pub fn set_error(&mut self, msg: impl Into<String>) {
+        self.app_mode = AppMode::Error(msg.into());
+    }
+
+    /// Revient au mode normal (ferme le panneau d'erreur).
+    pub fn clear_error(&mut self) {
+        self.app_mode = AppMode::Normal;
     }
 
     /// Invalide le cache de la liste visible (à appeler après toute modification

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use ratatui::widgets::ListState;
-use crate::config::{Config, ResolvedServer, ConfigEntry, ConnectionMode};
+use crate::config::{Config, ConfigError, ResolvedServer, ConfigEntry, ConnectionMode};
 
 #[derive(Debug, Clone)]
 pub enum ConfigItem {
@@ -25,8 +25,8 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(config: Config) -> Self {
-        let resolved = config.resolve().unwrap_or_default(); 
+    pub fn new(config: Config) -> Result<Self, ConfigError> {
+        let resolved = config.resolve()?;
         
         let mut app = Self {
             config,
@@ -46,7 +46,7 @@ impl App {
         app.expanded_items.clear();
         
         app.update_mode_from_selection();
-        app
+        Ok(app)
     }
 
     pub fn toggle_expansion(&mut self) {
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn test_initial_visibility() {
         let config = create_test_config();
-        let app = App::new(config);
+        let app = App::new(config).unwrap();
         let items = app.get_visible_items();
         
         // Initially only the group header is visible (collapsed state)
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn test_expansion() {
         let config = create_test_config();
-        let mut app = App::new(config);
+        let mut app = App::new(config).unwrap();
         
         // Expand Expand group G1
         app.toggle_expansion(); 
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn test_search_filtering() {
         let config = create_test_config();
-        let mut app = App::new(config);
+        let mut app = App::new(config).unwrap();
         
         app.search_query = "S1".to_string();
         let items = app.get_visible_items();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,28 @@
 use serde::Deserialize;
 use thiserror::Error;
 use std::path::Path;
+use std::fmt;
+
+/// Mode de connexion SSH. Remplace les chaînes magiques "direct"/"jump"/"bastion".
+/// Copy car l'enum ne contient aucune donnée — pas besoin de clone explicite.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ConnectionMode {
+    #[default]
+    Direct,
+    Jump,
+    Bastion,
+}
+
+impl fmt::Display for ConnectionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConnectionMode::Direct => write!(f, "direct"),
+            ConnectionMode::Jump => write!(f, "jump"),
+            ConnectionMode::Bastion => write!(f, "bastion"),
+        }
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum ConfigError {
@@ -29,7 +51,7 @@ pub enum ConfigEntry {
 pub struct Defaults {
     pub user: Option<String>,
     pub ssh_key: Option<String>,
-    pub mode: Option<String>,
+    pub mode: Option<ConnectionMode>,
     pub ssh_port: Option<u16>,
     pub ssh_options: Option<Vec<String>>,
     pub bastion: Option<BastionConfig>,
@@ -54,7 +76,7 @@ pub struct Group {
     pub name: String,
     pub user: Option<String>,
     pub ssh_key: Option<String>,
-    pub mode: Option<String>,
+    pub mode: Option<ConnectionMode>,
     pub ssh_port: Option<u16>,
     pub ssh_options: Option<Vec<String>>,
     pub bastion: Option<BastionConfig>,
@@ -68,7 +90,7 @@ pub struct Environment {
     pub name: String,
     pub user: Option<String>,
     pub ssh_key: Option<String>,
-    pub mode: Option<String>,
+    pub mode: Option<ConnectionMode>,
     pub ssh_port: Option<u16>,
     pub ssh_options: Option<Vec<String>>,
     pub bastion: Option<BastionConfig>,
@@ -84,7 +106,7 @@ pub struct Server {
     pub ssh_key: Option<String>,
     pub ssh_port: Option<u16>,
     pub ssh_options: Option<Vec<String>>,
-    pub mode: Option<String>, // "direct", "jump", "bastion"
+    pub mode: Option<ConnectionMode>,
     pub bastion: Option<BastionConfig>,
     pub rebond: Option<JumpConfig>,
 }
@@ -99,7 +121,7 @@ pub struct ResolvedServer {
     pub port: u16,
     pub ssh_key: String,
     pub ssh_options: Vec<String>,
-    pub default_mode: String, 
+    pub default_mode: ConnectionMode,
     pub jump_host: Option<String>,
     pub jump_user: Option<String>,
     pub bastion_host: Option<String>,
@@ -159,7 +181,7 @@ impl Config {
                     // Merge defaults -> Group
                     let g_user = group.user.as_deref().or(d.user.as_deref());
                     let g_key = group.ssh_key.as_deref().or(d.ssh_key.as_deref());
-                    let g_mode = group.mode.as_deref().or(d.mode.as_deref());
+                    let g_mode = group.mode.or(d.mode);
                     let g_port = group.ssh_port.or(d.ssh_port);
                     let g_opts = if let Some(opts) = &group.ssh_options {
                          Some(opts.clone())
@@ -175,7 +197,7 @@ impl Config {
                             // Merge Group -> Env
                             let e_user = env.user.as_deref().or(g_user);
                             let e_key = env.ssh_key.as_deref().or(g_key);
-                            let e_mode = env.mode.as_deref().or(g_mode);
+                            let e_mode = env.mode.or(g_mode);
                             let e_port = env.ssh_port.or(g_port);
                             let e_opts = if let Some(opts) = &env.ssh_options {
                                  Some(opts.clone())
@@ -219,7 +241,7 @@ impl Config {
                          server, 
                          "", 
                          "",
-                         d.user.as_deref(), d.ssh_key.as_deref(), d.mode.as_deref(), d.ssh_port, d.ssh_options.as_ref(),
+                         d.user.as_deref(), d.ssh_key.as_deref(), d.mode, d.ssh_port, d.ssh_options.as_ref(),
                          &d.bastion, &d.rebond
                      )?;
                      resolved.push(r);
@@ -266,7 +288,7 @@ fn resolve_server(
     env: &str,
     def_user: Option<&str>,
     def_key: Option<&str>,
-    def_mode: Option<&str>,
+    def_mode: Option<ConnectionMode>,
     def_port: Option<u16>,
     def_opts: Option<&Vec<String>>,
     def_bastion: &Option<BastionConfig>,
@@ -286,7 +308,7 @@ fn resolve_server(
     let final_bastion = merge_bastion(def_bastion, &s.bastion);
     let final_jump = merge_jump(def_jump, &s.rebond);
 
-    let mode_str = s.mode.as_deref().or(def_mode).unwrap_or("direct").to_string();
+    let mode = s.mode.or(def_mode).unwrap_or(ConnectionMode::Direct);
     
     let bastion_template = final_bastion.as_ref()
         .and_then(|b| b.template.clone())
@@ -301,7 +323,7 @@ fn resolve_server(
         port,
         ssh_key: key,
         ssh_options: opts,
-        default_mode: mode_str,
+        default_mode: mode,
         
         jump_host: final_jump.as_ref().and_then(|j| j.host.clone()),
         jump_user: final_jump.as_ref().and_then(|j| j.user.clone()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,9 @@ pub struct Defaults {
     pub ssh_options: Option<Vec<String>>,
     pub bastion: Option<BastionConfig>,
     pub rebond: Option<JumpConfig>,
+    /// Si `true`, ne passe pas `-F /dev/null` afin de respecter `~/.ssh/config`.
+    /// Défaut : `false` (comportement historique).
+    pub use_system_ssh_config: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -152,6 +155,8 @@ pub struct ResolvedServer {
     pub bastion_host: Option<String>,
     pub bastion_user: Option<String>,
     pub bastion_template: String,
+    /// Respecte `~/.ssh/config` si `true` (ne passe pas `-F /dev/null`).
+    pub use_system_ssh_config: bool,
 }
 
 impl Config {
@@ -199,6 +204,7 @@ impl Config {
         let mut resolved = Vec::new();
         
         let d = self.defaults.clone().unwrap_or_default();
+        let use_sys_cfg = d.use_system_ssh_config.unwrap_or(false);
         
         for entry in &self.groups {
             match entry {
@@ -238,8 +244,8 @@ impl Config {
                                      server, 
                                      &group.name, 
                                      &env.name,
-                                     e_user, e_key, e_mode, e_port, e_opts.as_ref(), // Pass ref
-                                     &e_bastion, &e_jump
+                                     e_user, e_key, e_mode, e_port, e_opts.as_ref(),
+                                     &e_bastion, &e_jump, use_sys_cfg
                                  )?;
                                  resolved.push(r);
                             }
@@ -253,7 +259,7 @@ impl Config {
                                  &group.name, 
                                  "",
                                  g_user, g_key, g_mode, g_port, g_opts.as_ref(),
-                                 &g_bastion, &g_jump
+                                 &g_bastion, &g_jump, use_sys_cfg
                              )?;
                              resolved.push(r);
                         }
@@ -267,7 +273,7 @@ impl Config {
                          "", 
                          "",
                          d.user.as_deref(), d.ssh_key.as_deref(), d.mode, d.ssh_port, d.ssh_options.as_ref(),
-                         &d.bastion, &d.rebond
+                         &d.bastion, &d.rebond, use_sys_cfg
                      )?;
                      resolved.push(r);
                 }
@@ -318,6 +324,7 @@ fn resolve_server(
     def_opts: Option<&Vec<String>>,
     def_bastion: &Option<BastionConfig>,
     def_jump: &Option<JumpConfig>,
+    use_system_ssh_config: bool,
 ) -> Result<ResolvedServer, ConfigError> {
     
     let user = s.user.as_deref().or(def_user).unwrap_or("root").to_string();
@@ -349,12 +356,12 @@ fn resolve_server(
         ssh_key: key,
         ssh_options: opts,
         default_mode: mode,
-        
         jump_host: final_jump.as_ref().and_then(|j| j.host.clone()),
         jump_user: final_jump.as_ref().and_then(|j| j.user.clone()),
         bastion_host: final_bastion.as_ref().and_then(|b| b.host.clone()),
         bastion_user: final_bastion.as_ref().and_then(|b| b.user.clone()),
         bastion_template,
+        use_system_ssh_config,
     })
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,16 @@ pub enum ConfigEntry {
     Group(Group),
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ThemeVariant {
+    Latte,
+    Frappe,
+    Macchiato,
+    #[default]
+    Mocha,
+}
+
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct Defaults {
     pub user: Option<String>,
@@ -84,6 +94,9 @@ pub struct Defaults {
     /// Si `true`, ne passe pas `-F /dev/null` afin de respecter `~/.ssh/config`.
     /// Défaut : `false` (comportement historique).
     pub use_system_ssh_config: Option<bool>,
+    /// Variante Catppuccin à utiliser pour le thème TUI.
+    /// Valeurs : `latte`, `frappe`, `macchiato`, `mocha` (défaut).
+    pub theme: Option<ThemeVariant>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,31 @@ impl fmt::Display for ConnectionMode {
     }
 }
 
+impl ConnectionMode {
+    /// Indice tab (Direct=0, Jump=1, Bastion=2) — utilisé par l'UI Tabs::select().
+    pub fn index(self) -> usize {
+        match self {
+            ConnectionMode::Direct => 0,
+            ConnectionMode::Jump => 1,
+            ConnectionMode::Bastion => 2,
+        }
+    }
+
+    /// Construit depuis un indice tab. Retourne Direct pour tout indice inconnu.
+    pub fn from_index(i: usize) -> Self {
+        match i {
+            1 => ConnectionMode::Jump,
+            2 => ConnectionMode::Bastion,
+            _ => ConnectionMode::Direct,
+        }
+    }
+
+    /// Passe au mode suivant en boucle (Direct → Jump → Bastion → Direct).
+    pub fn next(self) -> Self {
+        Self::from_index((self.index() + 1) % 3)
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("IO error: {0}")]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -2,6 +2,7 @@ use std::io;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use crossterm::event::MouseEvent;
 use crate::app::App;
+use crate::config::ConnectionMode;
 
 pub struct AppLayout {
     pub list_area: Rect,
@@ -58,7 +59,7 @@ pub fn handle_mouse_event(mouse: MouseEvent, app: &mut App, size: Rect) -> io::R
             let width = title.chars().count();
             // Check if click is strictly within the title text
             if rel_x >= current_x && rel_x < current_x + width {
-                app.connection_mode = i;
+                app.connection_mode = ConnectionMode::from_index(i);
                 return Ok(true);
             }
             // Advance cursor (title + separator)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod config;
+pub mod state;
 pub mod ui;
 pub mod ssh;
 pub mod handlers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,16 +267,19 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
                                 app.search_query.clear();
                                 app.selected_index = 0;
                                 app.list_state.select(Some(0));
+                                app.invalidate_cache();
                             }
                             KeyCode::Char(c) => {
                                 app.search_query.push(c);
                                 app.selected_index = 0;
                                 app.list_state.select(Some(0));
+                                app.invalidate_cache();
                             }
                             KeyCode::Backspace => {
                                 app.search_query.pop();
                                 app.selected_index = 0;
                                 app.list_state.select(Some(0));
+                                app.invalidate_cache();
                             }
                             _ => {}
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use ratatui::{backend::CrosstermBackend, Terminal, layout::Rect};
 
 use sushi::app::{App, ConfigItem};
 use sushi::config::{Config, ConnectionMode, ResolvedServer};
+use sushi::ssh::client::build_ssh_args;
 use sushi::ui;
 use sushi::handlers::{handle_mouse_event, get_layout, is_in_rect};
 
@@ -247,6 +248,13 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
 
         terminal.draw(|f| ui::draw(f, app))?;
 
+        // Expire le message de statut après 3 secondes
+        if let Some((_, ts)) = &app.status_message {
+            if ts.elapsed() > Duration::from_secs(3) {
+                app.status_message = None;
+            }
+        }
+
         if event::poll(Duration::from_millis(250))? {
             match event::read()? {
                 Event::Key(key) => {
@@ -292,6 +300,21 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
                             }
                             KeyCode::Char('v') => {
                                 app.verbose_mode = !app.verbose_mode;
+                            }
+                            KeyCode::Char('y') => {
+                                let items = app.get_visible_items();
+                                if let Some(ConfigItem::Server(server)) = items.get(app.selected_index) {
+                                    match build_ssh_args(server, app.connection_mode, app.verbose_mode) {
+                                        Ok(args) => {
+                                            let cmd = format!("ssh {}", args.join(" "));
+                                            match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(&cmd)) {
+                                                Ok(_) => app.set_status_message(format!("Copied: {cmd}")),
+                                                Err(e) => app.set_status_message(format!("Clipboard error: {e}")),
+                                            }
+                                        }
+                                        Err(e) => app.set_status_message(format!("SSH error: {e}")),
+                                    }
+                                }
                             }
                             KeyCode::Char('/') => {
                                 app.is_searching = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use ratatui::{backend::CrosstermBackend, Terminal, layout::Rect};
 use sushi::app::{App, ConfigItem};
 use sushi::config::{Config, ConnectionMode, ResolvedServer};
 use sushi::ssh::client::build_ssh_args;
+use sushi::state;
 use sushi::ui;
 use sushi::handlers::{handle_mouse_event, get_layout, is_in_rect};
 
@@ -207,6 +208,9 @@ fn main() -> io::Result<()> {
     let mut app = App::new(config).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
     let res = run_app(&mut terminal, &mut app);
+
+    // Persiste l'état d'expansion avant de quitter la TUI
+    state::save_state(&app.to_app_state());
 
     disable_raw_mode()?;
     execute!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use crossterm::{
 use ratatui::{backend::CrosstermBackend, Terminal, layout::Rect};
 
 use sushi::app::{App, ConfigItem};
-use sushi::config::Config;
+use sushi::config::{Config, ConnectionMode};
 use sushi::ui;
 use sushi::handlers::{handle_mouse_event, get_layout, is_in_rect};
 
@@ -107,7 +107,7 @@ fn main() -> io::Result<()> {
 
 pub enum AppResult {
     Exit,
-    Connect(sushi::config::ResolvedServer, usize, bool),
+    Connect(sushi::config::ResolvedServer, ConnectionMode, bool),
 }
 
 fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App) -> io::Result<AppResult> {
@@ -152,16 +152,16 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
                                 app.previous();
                             }
                             KeyCode::Tab => {
-                                app.connection_mode = (app.connection_mode + 1) % 3;
+                                app.connection_mode = app.connection_mode.next();
                             }
                             KeyCode::Char('1') => {
-                                app.connection_mode = 0;
+                                app.connection_mode = ConnectionMode::Direct;
                             }
                             KeyCode::Char('2') => {
-                                app.connection_mode = 1;
+                                app.connection_mode = ConnectionMode::Jump;
                             }
                             KeyCode::Char('3') => {
-                                app.connection_mode = 2;
+                                app.connection_mode = ConnectionMode::Bastion;
                             }
                             KeyCode::Char('v') => {
                                 app.verbose_mode = !app.verbose_mode;

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,7 @@ fn build_adhoc_server(
         bastion_host,
         bastion_user,
         bastion_template,
+        use_system_ssh_config: false,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn main() -> io::Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = App::new(config);
+    let mut app = App::new(config).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
     let res = run_app(&mut terminal, &mut app);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::{io, time::Duration};
 
+use clap::Parser;
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, MouseEventKind, MouseButton},
     execute,
@@ -8,9 +9,50 @@ use crossterm::{
 use ratatui::{backend::CrosstermBackend, Terminal, layout::Rect};
 
 use sushi::app::{App, ConfigItem};
-use sushi::config::{Config, ConnectionMode};
+use sushi::config::{Config, ConnectionMode, ResolvedServer};
 use sushi::ui;
 use sushi::handlers::{handle_mouse_event, get_layout, is_in_rect};
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+
+/// 🍣 Sushi — terminal SSH connection manager
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Chemin vers le fichier de configuration (défaut : ~/.sushi.yml)
+    #[arg(short, long, value_name = "FILE")]
+    config: Option<String>,
+
+    /// Connexion directe sans TUI : [user@]host[:port]
+    #[arg(long, value_name = "[USER@]HOST[:PORT]", conflicts_with_all = ["rebond", "bastion"])]
+    direct: Option<String>,
+
+    /// Connexion via jump host sans TUI : [user@]host[:port]
+    #[arg(long, value_name = "[USER@]HOST[:PORT]", conflicts_with_all = ["direct", "bastion"])]
+    rebond: Option<String>,
+
+    /// Connexion via bastion sans TUI : [user@]host[:port]
+    #[arg(long, value_name = "[USER@]HOST[:PORT]", conflicts_with_all = ["direct", "rebond"])]
+    bastion: Option<String>,
+
+    /// Forcer un utilisateur SSH (remplace la config et le user@host)
+    #[arg(short, long, value_name = "USER")]
+    user: Option<String>,
+
+    /// Forcer un port SSH
+    #[arg(short, long, value_name = "PORT")]
+    port: Option<u16>,
+
+    /// Forcer une clé SSH
+    #[arg(short, long, value_name = "PATH")]
+    key: Option<String>,
+
+    /// Activer le mode verbeux SSH (-v)
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+// ─── Config par défaut ───────────────────────────────────────────────────────
 
 const DEFAULT_CONFIG: &str = r#"
 defaults:
@@ -37,20 +79,85 @@ groups:
             mode: "jump"
 "#;
 
-fn main() -> io::Result<()> {
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
-    let config_path_cow = shellexpand::tilde("~/.sushi.yml");
-    let config_path = std::path::Path::new(config_path_cow.as_ref());
+/// Décompose `[user@]host[:port]` en ses parties.
+fn parse_target(s: &str) -> (Option<String>, String, Option<u16>) {
+    let (user, rest) = if let Some((u, r)) = s.split_once('@') {
+        (Some(u.to_string()), r)
+    } else {
+        (None, s)
+    };
+    let (host, port) = if let Some((h, p)) = rest.split_once(':') {
+        (h.to_string(), p.parse().ok())
+    } else {
+        (rest.to_string(), None)
+    };
+    (user, host, port)
+}
+
+/// Construit un `ResolvedServer` minimal pour une connexion sans TUI.
+fn build_adhoc_server(
+    target: &str,
+    mode: ConnectionMode,
+    cli: &Cli,
+    config: &Config,
+) -> ResolvedServer {
+    let (parsed_user, host, parsed_port) = parse_target(target);
+    let d = config.defaults.clone().unwrap_or_default();
+
+    let user = cli.user.clone()
+        .or(parsed_user)
+        .or(d.user.clone())
+        .unwrap_or_else(|| "root".to_string());
+    let port = cli.port
+        .or(parsed_port)
+        .or(d.ssh_port)
+        .unwrap_or(22);
+    let ssh_key = cli.key.clone()
+        .or(d.ssh_key.clone())
+        .unwrap_or_else(|| "~/.ssh/id_rsa".to_string());
+    let ssh_options = d.ssh_options.clone().unwrap_or_default();
+
+    let jump_host  = d.rebond.as_ref().and_then(|j| j.host.clone());
+    let jump_user  = d.rebond.as_ref().and_then(|j| j.user.clone());
+    let bastion_host = d.bastion.as_ref().and_then(|b| b.host.clone());
+    let bastion_user = d.bastion.as_ref().and_then(|b| b.user.clone());
+    let bastion_template = d.bastion.as_ref()
+        .and_then(|b| b.template.clone())
+        .unwrap_or_else(|| "{target_user}@%n:SSH:{bastion_user}".to_string());
+
+    ResolvedServer {
+        group_name: String::new(),
+        env_name: String::new(),
+        name: host.clone(),
+        host,
+        user,
+        port,
+        ssh_key,
+        ssh_options,
+        default_mode: mode,
+        jump_host,
+        jump_user,
+        bastion_host,
+        bastion_user,
+        bastion_template,
+    }
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+fn main() -> io::Result<()> {
+    let cli = Cli::parse();
+
+    // Résolution du chemin de config
+    let config_path_str = cli.config.clone().unwrap_or_else(|| {
+        shellexpand::tilde("~/.sushi.yml").into_owned()
+    });
+    let config_path = std::path::Path::new(&config_path_str);
 
     if !config_path.exists() {
         if let Err(e) = std::fs::write(config_path, DEFAULT_CONFIG) {
-            disable_raw_mode()?;
-            execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
             eprintln!("Failed to create default config: {}", e);
             return Err(e);
         }
@@ -59,8 +166,6 @@ fn main() -> io::Result<()> {
     let config_content = match std::fs::read_to_string(config_path) {
         Ok(c) => c,
         Err(e) => {
-            disable_raw_mode()?;
-            execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
             eprintln!("Failed to read config: {}", e);
             return Err(e);
         }
@@ -69,14 +174,33 @@ fn main() -> io::Result<()> {
     let mut config: Config = match serde_yaml::from_str(&config_content) {
         Ok(c) => c,
         Err(e) => {
-            disable_raw_mode()?;
-            execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
             eprintln!("Failed to parse YAML config: {}", e);
             return Err(io::Error::new(io::ErrorKind::InvalidData, e));
         }
     };
-
     config.sort();
+
+    // ── Connexion directe sans TUI ──────────────────────────────────────────
+    let cli_mode_target: Option<(ConnectionMode, String)> =
+        cli.direct.as_deref().map(|t| (ConnectionMode::Direct, t.to_string()))
+        .or_else(|| cli.rebond.as_deref().map(|t| (ConnectionMode::Jump, t.to_string())))
+        .or_else(|| cli.bastion.as_deref().map(|t| (ConnectionMode::Bastion, t.to_string())));
+
+    if let Some((mode, target)) = cli_mode_target {
+        let server = build_adhoc_server(&target, mode, &cli, &config);
+        if let Err(e) = sushi::ssh::client::connect(&server, mode, cli.verbose) {
+            eprintln!("SSH Connection Error: {}", e);
+            return Err(io::Error::new(io::ErrorKind::Other, e.to_string()));
+        }
+        return Ok(()); // exec() remplace le process ; on n'arrive jamais ici
+    }
+
+    // ── Mode TUI normal ─────────────────────────────────────────────────────
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
 
     let mut app = App::new(config);
 
@@ -94,7 +218,7 @@ fn main() -> io::Result<()> {
         Ok(AppResult::Exit) => {},
         Ok(AppResult::Connect(server, mode, verbose)) => {
             if let Err(e) = sushi::ssh::client::connect(&server, mode, verbose) {
-                 eprintln!("SSH Connection Error: {}", e);
+                eprintln!("SSH Connection Error: {}", e);
             }
         },
         Err(err) => {
@@ -105,6 +229,8 @@ fn main() -> io::Result<()> {
     Ok(())
 }
 
+// ─── TUI ─────────────────────────────────────────────────────────────────────
+
 pub enum AppResult {
     Exit,
     Connect(sushi::config::ResolvedServer, ConnectionMode, bool),
@@ -113,7 +239,7 @@ pub enum AppResult {
 fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App) -> io::Result<AppResult> {
     let mut last_click_time = std::time::Instant::now();
     let mut last_click_pos = (0, 0);
-    
+
     loop {
         let size_obj = terminal.size()?;
         let size = Rect::new(0, 0, size_obj.width, size_obj.height);
@@ -193,15 +319,15 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
                     match mouse.kind {
                         MouseEventKind::Down(MouseButton::Left) => {
                             let handled = handle_mouse_event(mouse, app, size)?;
-                            
+
                             let now = std::time::Instant::now();
                             if handled && now.duration_since(last_click_time) < Duration::from_millis(400) && last_click_pos == (mouse.column, mouse.row) {
                                 let layout = get_layout(size);
                                 if is_in_rect(mouse.column, mouse.row, layout.list_area) {
-                                     let items = app.get_visible_items();
-                                     if let Some(ConfigItem::Server(server)) = items.get(app.selected_index) {
-                                         return Ok(AppResult::Connect(server.clone(), app.connection_mode, app.verbose_mode));
-                                     }
+                                    let items = app.get_visible_items();
+                                    if let Some(ConfigItem::Server(server)) = items.get(app.selected_index) {
+                                        return Ok(AppResult::Connect(server.clone(), app.connection_mode, app.verbose_mode));
+                                    }
                                 }
                             }
                             last_click_time = now;
@@ -215,3 +341,4 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
         }
     }
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use crossterm::{
 };
 use ratatui::{backend::CrosstermBackend, Terminal, layout::Rect};
 
-use sushi::app::{App, ConfigItem};
+use sushi::app::{App, AppMode, ConfigItem};
 use sushi::config::{Config, ConnectionMode, ResolvedServer};
 use sushi::ssh::client::build_ssh_args;
 use sushi::state;
@@ -262,7 +262,13 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
         if event::poll(Duration::from_millis(250))? {
             match event::read()? {
                 Event::Key(key) => {
-                    if app.is_searching {
+                    if app.app_mode != AppMode::Normal {
+                        // En mode erreur : n'importe quelle touche ferme le panneau
+                        match key.code {
+                            KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => app.clear_error(),
+                            _ => {}
+                        }
+                    } else if app.is_searching {
                         match key.code {
                             KeyCode::Enter | KeyCode::Esc => {
                                 app.is_searching = false;
@@ -335,16 +341,22 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
                                 app.toggle_expansion();
                             }
                             KeyCode::Enter => {
-                                let items = app.get_visible_items();
-                                if let Some(item) = items.get(app.selected_index) {
-                                    match item {
-                                        ConfigItem::Server(server) => {
-                                            return Ok(AppResult::Connect(server.clone(), app.connection_mode, app.verbose_mode));
+                                let action = {
+                                    let items = app.get_visible_items();
+                                    match items.get(app.selected_index) {
+                                        Some(ConfigItem::Server(server)) => {
+                                            match build_ssh_args(server, app.connection_mode, app.verbose_mode) {
+                                                Ok(_) => Some(Ok(server.clone())),
+                                                Err(e) => Some(Err(format!("{e}"))),
+                                            }
                                         }
-                                        _ => {
-                                            app.toggle_expansion();
-                                        }
+                                        _ => None,
                                     }
+                                };
+                                match action {
+                                    Some(Ok(server)) => return Ok(AppResult::Connect(server, app.connection_mode, app.verbose_mode)),
+                                    Some(Err(msg)) => app.set_error(msg),
+                                    None => app.toggle_expansion(),
                                 }
                             }
                             _ => {}
@@ -360,9 +372,22 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
                             if handled && now.duration_since(last_click_time) < Duration::from_millis(400) && last_click_pos == (mouse.column, mouse.row) {
                                 let layout = get_layout(size);
                                 if is_in_rect(mouse.column, mouse.row, layout.list_area) {
-                                    let items = app.get_visible_items();
-                                    if let Some(ConfigItem::Server(server)) = items.get(app.selected_index) {
-                                        return Ok(AppResult::Connect(server.clone(), app.connection_mode, app.verbose_mode));
+                                    let action = {
+                                        let items = app.get_visible_items();
+                                        match items.get(app.selected_index) {
+                                            Some(ConfigItem::Server(server)) => {
+                                                match build_ssh_args(server, app.connection_mode, app.verbose_mode) {
+                                                    Ok(_) => Some(Ok(server.clone())),
+                                                    Err(e) => Some(Err(format!("{e}"))),
+                                                }
+                                            }
+                                            _ => None,
+                                        }
+                                    };
+                                    match action {
+                                        Some(Ok(server)) => return Ok(AppResult::Connect(server, app.connection_mode, app.verbose_mode)),
+                                        Some(Err(msg)) => app.set_error(msg),
+                                        None => {}
                                     }
                                 }
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::{io, time::Duration};
 
 use clap::Parser;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, MouseEventKind, MouseButton},
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers, MouseEventKind, MouseButton},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -262,6 +262,11 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
                         match key.code {
                             KeyCode::Enter | KeyCode::Esc => {
                                 app.is_searching = false;
+                            }
+                            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                app.search_query.clear();
+                                app.selected_index = 0;
+                                app.list_state.select(Some(0));
                             }
                             KeyCode::Char(c) => {
                                 app.search_query.push(c);

--- a/src/ssh/client.rs
+++ b/src/ssh/client.rs
@@ -1,10 +1,9 @@
 use std::process::Command;
 use std::os::unix::process::CommandExt; // Import exec
-use crate::config::ResolvedServer;
+use crate::config::{ResolvedServer, ConnectionMode};
 use anyhow::{Result};
 
-pub fn connect(server: &ResolvedServer, mode: usize, verbose: bool) -> Result<()> {
-    // Mode: 0=Direct, 1=Jump, 2=Bastion
+pub fn connect(server: &ResolvedServer, mode: ConnectionMode, verbose: bool) -> Result<()> {
     
     let mut command = Command::new("ssh");
     
@@ -20,49 +19,38 @@ pub fn connect(server: &ResolvedServer, mode: usize, verbose: bool) -> Result<()
     // command.arg("-t"); 
 
     match mode {
-        0 => { // Direct
+        ConnectionMode::Direct => {
             add_target_args(&mut command, &server.user, &server.host);
         },
-        1 => { // Jump
+        ConnectionMode::Jump => {
             let jump_host_str = server.jump_host.as_deref().unwrap_or("");
             if jump_host_str.is_empty() {
                 return Err(anyhow::anyhow!("Jump host not configured for this server"));
             }
             let jump_user = server.jump_user.as_deref().unwrap_or(&server.user);
-            
-            // Format: jump_user@jump_host[:port]
-            // We need to parse port if present in jump_host_str
             let jump_arg = format_host_arg(jump_user, jump_host_str);
-            
             command.arg("-J").arg(jump_arg);
-            
             add_target_args(&mut command, &server.user, &server.host);
         },
-        2 => { // Bastion
+        ConnectionMode::Bastion => {
             let bastion_host_str = server.bastion_host.as_deref().unwrap_or("");
             if bastion_host_str.is_empty() {
-                 return Err(anyhow::anyhow!("Bastion host not configured for this server"));
+                return Err(anyhow::anyhow!("Bastion host not configured for this server"));
             }
-
-            let bastion_user = server.bastion_user.as_deref().unwrap_or("root"); 
-
+            let bastion_user = server.bastion_user.as_deref().unwrap_or("root");
             let (t_host, _t_port) = parse_host_port(&server.host);
             let user_string = server.bastion_template
                 .replace("{target_user}", &server.user)
                 .replace("{target_host}", t_host)
                 .replace("{bastion_user}", bastion_user)
                 .replace("%n", t_host);
-            
-            // Connect to bastion as the specific user string
             command.arg("-l").arg(user_string);
-            
             let (b_host, b_port) = parse_host_port(bastion_host_str);
             if let Some(p) = b_port {
                 command.arg("-p").arg(p);
             }
             command.arg(b_host);
         },
-        _ => return Err(anyhow::anyhow!("Invalid connection mode")),
     }
 
     if !server.ssh_key.is_empty() {

--- a/src/ssh/client.rs
+++ b/src/ssh/client.rs
@@ -1,29 +1,26 @@
 use std::process::Command;
-use std::os::unix::process::CommandExt; // Import exec
+use std::os::unix::process::CommandExt;
 use crate::config::{ResolvedServer, ConnectionMode};
-use anyhow::{Result};
+use anyhow::Result;
 
-pub fn connect(server: &ResolvedServer, mode: ConnectionMode, verbose: bool) -> Result<()> {
-    
-    let mut command = Command::new("ssh");
+/// Construit la liste complète des arguments SSH sans lancer de processus.
+/// Séparé de `connect()` pour être testable unitairement.
+pub fn build_ssh_args(server: &ResolvedServer, mode: ConnectionMode, verbose: bool) -> Result<Vec<String>> {
+    let mut args: Vec<String> = Vec::new();
 
-    // Ignore ~/.ssh/config unless the user explicitly opts in via `use_system_ssh_config: true`.
     if !server.use_system_ssh_config {
-        command.arg("-F").arg("/dev/null");
-    }
-    
-    // Add verbose flag if enabled
-    if verbose {
-        command.arg("-v");
+        args.push("-F".into());
+        args.push("/dev/null".into());
     }
 
-    // Add extra args if needed, e.g. -t for forcing TTY allocation
-    // command.arg("-t"); 
+    if verbose {
+        args.push("-v".into());
+    }
 
     match mode {
         ConnectionMode::Direct => {
-            add_target_args(&mut command, &server.user, &server.host);
-        },
+            collect_target_args(&mut args, &server.user, &server.host);
+        }
         ConnectionMode::Jump => {
             let jump_host_str = server.jump_host.as_deref().unwrap_or("");
             if jump_host_str.is_empty() {
@@ -31,9 +28,10 @@ pub fn connect(server: &ResolvedServer, mode: ConnectionMode, verbose: bool) -> 
             }
             let jump_user = server.jump_user.as_deref().unwrap_or(&server.user);
             let jump_arg = format_host_arg(jump_user, jump_host_str);
-            command.arg("-J").arg(jump_arg);
-            add_target_args(&mut command, &server.user, &server.host);
-        },
+            args.push("-J".into());
+            args.push(jump_arg);
+            collect_target_args(&mut args, &server.user, &server.host);
+        }
         ConnectionMode::Bastion => {
             let bastion_host_str = server.bastion_host.as_deref().unwrap_or("");
             if bastion_host_str.is_empty() {
@@ -46,44 +44,53 @@ pub fn connect(server: &ResolvedServer, mode: ConnectionMode, verbose: bool) -> 
                 .replace("{target_host}", t_host)
                 .replace("{bastion_user}", bastion_user)
                 .replace("%n", t_host);
-            command.arg("-l").arg(user_string);
+            args.push("-l".into());
+            args.push(user_string);
             let (b_host, b_port) = parse_host_port(bastion_host_str);
             if let Some(p) = b_port {
-                command.arg("-p").arg(p);
+                args.push("-p".into());
+                args.push(p.to_string());
             }
-            command.arg(b_host);
-        },
+            args.push(b_host.to_string());
+        }
     }
 
     if !server.ssh_key.is_empty() {
         let expanded = shellexpand::tilde(&server.ssh_key);
-        command.arg("-i").arg(expanded.as_ref());
+        args.push("-i".into());
+        args.push(expanded.into_owned());
     }
-    
-    // Add custom SSH options
+
     for opt in &server.ssh_options {
-        // Simple heuristic: if it starts with hyphen, treat as flag, else option
         if opt.starts_with('-') {
-            command.arg(opt);
+            args.push(opt.clone());
         } else {
-            command.arg("-o").arg(opt);
+            args.push("-o".into());
+            args.push(opt.clone());
         }
     }
 
-    // Replace current process with SSH
-    // If successful, this function never returns.
-    let err = command.exec();
+    Ok(args)
+}
 
-    // If we are here, exec failed
+/// Lance la connexion SSH en remplaçant le processus courant (`exec`).
+pub fn connect(server: &ResolvedServer, mode: ConnectionMode, verbose: bool) -> Result<()> {
+    let args = build_ssh_args(server, mode, verbose)?;
+    let mut command = Command::new("ssh");
+    command.args(&args);
+    let err = command.exec();
     Err(anyhow::Error::new(err).context("Failed to exec ssh command"))
 }
 
-fn add_target_args(cmd: &mut Command, user: &str, host_str: &str) {
+// ─── helpers privés ──────────────────────────────────────────────────────────
+
+fn collect_target_args(args: &mut Vec<String>, user: &str, host_str: &str) {
     let (host, port) = parse_host_port(host_str);
     if let Some(p) = port {
-        cmd.arg("-p").arg(p);
+        args.push("-p".into());
+        args.push(p.to_string());
     }
-    cmd.arg(format!("{}@{}", user, host));
+    args.push(format!("{}@{}", user, host));
 }
 
 fn format_host_arg(user: &str, host_str: &str) -> String {
@@ -102,4 +109,185 @@ fn parse_host_port(s: &str) -> (&str, Option<&str>) {
         (s, None)
     }
 }
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ConnectionMode;
+
+    fn base_server() -> ResolvedServer {
+        ResolvedServer {
+            group_name: "G".into(),
+            env_name: "E".into(),
+            name: "srv".into(),
+            host: "10.0.0.1".into(),
+            user: "admin".into(),
+            port: 22,
+            ssh_key: String::new(),
+            ssh_options: vec![],
+            default_mode: ConnectionMode::Direct,
+            jump_host: None,
+            jump_user: None,
+            bastion_host: None,
+            bastion_user: None,
+            bastion_template: "{target_user}@%n:SSH:{bastion_user}".into(),
+            use_system_ssh_config: false,
+        }
+    }
+
+    // ── mode Direct ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn direct_basic() {
+        let s = base_server();
+        let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+        assert!(args.contains(&"-F".to_string()));
+        assert!(args.contains(&"/dev/null".to_string()));
+        assert!(args.contains(&"admin@10.0.0.1".to_string()));
+        assert!(!args.contains(&"-v".to_string()));
+    }
+
+    #[test]
+    fn direct_verbose() {
+        let s = base_server();
+        let args = build_ssh_args(&s, ConnectionMode::Direct, true).unwrap();
+        assert!(args.contains(&"-v".to_string()));
+    }
+
+    #[test]
+    fn direct_with_port_in_host() {
+        let mut s = base_server();
+        s.host = "10.0.0.1:2222".into();
+        let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+        assert!(args.contains(&"-p".to_string()));
+        assert!(args.contains(&"2222".to_string()));
+        assert!(args.contains(&"admin@10.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn direct_with_ssh_key() {
+        let mut s = base_server();
+        s.ssh_key = "~/.ssh/id_ed25519".into();
+        let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+        let key_pos = args.iter().position(|a| a == "-i").expect("-i present");
+        assert!(!args[key_pos + 1].is_empty());
+    }
+
+    #[test]
+    fn direct_with_ssh_options() {
+        let mut s = base_server();
+        s.ssh_options = vec!["StrictHostKeyChecking=no".into(), "-T".into()];
+        let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+        // String option → prefixed with -o
+        let o_pos = args.iter().position(|a| a == "-o").expect("-o present");
+        assert_eq!(args[o_pos + 1], "StrictHostKeyChecking=no");
+        // Flag option → passed as-is
+        assert!(args.contains(&"-T".to_string()));
+    }
+
+    #[test]
+    fn direct_use_system_ssh_config() {
+        let mut s = base_server();
+        s.use_system_ssh_config = true;
+        let args = build_ssh_args(&s, ConnectionMode::Direct, false).unwrap();
+        assert!(!args.contains(&"-F".to_string()));
+    }
+
+    // ── mode Jump ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn jump_basic() {
+        let mut s = base_server();
+        s.jump_host = Some("jump.example.com".into());
+        s.jump_user = Some("juser".into());
+        let args = build_ssh_args(&s, ConnectionMode::Jump, false).unwrap();
+        let j_pos = args.iter().position(|a| a == "-J").expect("-J present");
+        assert_eq!(args[j_pos + 1], "juser@jump.example.com");
+        assert!(args.contains(&"admin@10.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn jump_with_port() {
+        let mut s = base_server();
+        s.jump_host = Some("jump.example.com:2222".into());
+        s.jump_user = Some("juser".into());
+        let args = build_ssh_args(&s, ConnectionMode::Jump, false).unwrap();
+        let j_pos = args.iter().position(|a| a == "-J").expect("-J present");
+        assert_eq!(args[j_pos + 1], "juser@jump.example.com:2222");
+    }
+
+    #[test]
+    fn jump_fallback_user() {
+        // jump_user absent → server user is used
+        let mut s = base_server();
+        s.jump_host = Some("jump.example.com".into());
+        s.jump_user = None;
+        let args = build_ssh_args(&s, ConnectionMode::Jump, false).unwrap();
+        let j_pos = args.iter().position(|a| a == "-J").expect("-J present");
+        assert_eq!(args[j_pos + 1], "admin@jump.example.com");
+    }
+
+    #[test]
+    fn jump_missing_host_returns_error() {
+        let s = base_server(); // jump_host = None
+        let err = build_ssh_args(&s, ConnectionMode::Jump, false).unwrap_err();
+        assert!(err.to_string().contains("Jump host not configured"));
+    }
+
+    // ── mode Bastion ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn bastion_basic() {
+        let mut s = base_server();
+        s.bastion_host = Some("bastion.example.com".into());
+        s.bastion_user = Some("buser".into());
+        let args = build_ssh_args(&s, ConnectionMode::Bastion, false).unwrap();
+        let l_pos = args.iter().position(|a| a == "-l").expect("-l present");
+        // template: {target_user}@%n:SSH:{bastion_user}
+        assert_eq!(args[l_pos + 1], "admin@10.0.0.1:SSH:buser");
+        assert!(args.contains(&"bastion.example.com".to_string()));
+    }
+
+    #[test]
+    fn bastion_with_port() {
+        let mut s = base_server();
+        s.bastion_host = Some("bastion.example.com:8022".into());
+        s.bastion_user = Some("buser".into());
+        let args = build_ssh_args(&s, ConnectionMode::Bastion, false).unwrap();
+        assert!(args.contains(&"-p".to_string()));
+        assert!(args.contains(&"8022".to_string()));
+        assert!(args.contains(&"bastion.example.com".to_string()));
+    }
+
+    #[test]
+    fn bastion_fallback_user() {
+        let mut s = base_server();
+        s.bastion_host = Some("bastion.example.com".into());
+        s.bastion_user = None; // fallback → "root"
+        let args = build_ssh_args(&s, ConnectionMode::Bastion, false).unwrap();
+        let l_pos = args.iter().position(|a| a == "-l").expect("-l present");
+        assert!(args[l_pos + 1].ends_with(":SSH:root"));
+    }
+
+    #[test]
+    fn bastion_missing_host_returns_error() {
+        let s = base_server(); // bastion_host = None
+        let err = build_ssh_args(&s, ConnectionMode::Bastion, false).unwrap_err();
+        assert!(err.to_string().contains("Bastion host not configured"));
+    }
+
+    #[test]
+    fn bastion_custom_template() {
+        let mut s = base_server();
+        s.bastion_host = Some("bastion.example.com".into());
+        s.bastion_user = Some("buser".into());
+        s.bastion_template = "{bastion_user}+{target_user}@{target_host}".into();
+        let args = build_ssh_args(&s, ConnectionMode::Bastion, false).unwrap();
+        let l_pos = args.iter().position(|a| a == "-l").expect("-l present");
+        assert_eq!(args[l_pos + 1], "buser+admin@10.0.0.1");
+    }
+}
+
 

--- a/src/ssh/client.rs
+++ b/src/ssh/client.rs
@@ -6,9 +6,11 @@ use anyhow::{Result};
 pub fn connect(server: &ResolvedServer, mode: ConnectionMode, verbose: bool) -> Result<()> {
     
     let mut command = Command::new("ssh");
-    
-    // Explicitly ignore user config as requested
-    command.arg("-F").arg("/dev/null");
+
+    // Ignore ~/.ssh/config unless the user explicitly opts in via `use_system_ssh_config: true`.
+    if !server.use_system_ssh_config {
+        command.arg("-F").arg("/dev/null");
+    }
     
     // Add verbose flag if enabled
     if verbose {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,36 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// État persistant de l'application (sauvegardé dans ~/.sushi_state.json).
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct AppState {
+    /// Clés des groupes/environnements actuellement développés ("Group:foo", "Env:foo:bar").
+    pub expanded_items: HashSet<String>,
+}
+
+fn state_path() -> PathBuf {
+    let raw = shellexpand::tilde("~/.sushi_state.json");
+    PathBuf::from(raw.as_ref())
+}
+
+/// Charge l'état depuis `~/.sushi_state.json`.
+/// Retourne un `AppState` par défaut si le fichier est absent ou invalide.
+pub fn load_state() -> AppState {
+    let path = state_path();
+    let Ok(content) = fs::read_to_string(&path) else {
+        return AppState::default();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+/// Persiste l'état dans `~/.sushi_state.json`.
+/// Les erreurs d'écriture sont silencieuses (non bloquantes).
+pub fn save_state(state: &AppState) {
+    let path = state_path();
+    if let Ok(json) = serde_json::to_string_pretty(state) {
+        let _ = fs::write(path, json);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -92,7 +92,7 @@ fn draw_verbose_toggle(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(verbose, area);
 }
 
-fn draw_search_bar(f: &mut Frame, app: &App, area: Rect) {
+fn draw_search_bar(f: &mut Frame, app: &mut App, area: Rect) {
     let visible_items = app.get_visible_items();
     let server_count = visible_items.iter().filter(|item| matches!(item, ConfigItem::Server(_))).count();
     let total_servers = app.resolved_servers.len();
@@ -226,7 +226,7 @@ fn draw_tree(f: &mut Frame, app: &mut App, area: Rect) {
     f.render_stateful_widget(list, area, &mut app.list_state);
 }
 
-fn draw_details(f: &mut Frame, app: &App, area: Rect) {
+fn draw_details(f: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -285,12 +285,20 @@ fn draw_details(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
+    // Affiche le message temporaire (clipboard, erreur…) si présent
+    if let Some((msg, _)) = &app.status_message {
+        let paragraph = Paragraph::new(msg.as_str())
+            .style(Style::default().bg(CATPPUCCIN_MOCHA.selection_bg).fg(CATPPUCCIN_MOCHA.green));
+        f.render_widget(paragraph, area);
+        return;
+    }
+
     let text = if app.is_searching {
         "Search Mode: Type to filter | ESC: Cancel | Enter: Apply"
     } else if !app.search_query.is_empty() {
         "Navigate: ↑/↓ | Clear: ESC | New search: / | Verbose: v | Enter: Connect | q: Quit"
     } else {
-        "Navigate: ↑/↓ | Expand: Space/Enter | Search: / | Mode: Tab/1-3 | Verbose: v | q: Quit"
+        "Navigate: ↑/↓ | Expand: Space/Enter | Search: / | Mode: Tab/1-3 | Verbose: v | y: Copy cmd | q: Quit"
     };
     let paragraph = Paragraph::new(text)
         .style(Style::default().bg(CATPPUCCIN_MOCHA.selection_bg).fg(CATPPUCCIN_MOCHA.fg));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,7 +10,7 @@ use ratatui::{
 };
 
 use crate::app::{App, AppMode, ConfigItem};
-use crate::ui::theme::CATPPUCCIN_MOCHA;
+use crate::ui::theme::Theme;
 
 pub fn draw(f: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
@@ -42,7 +42,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 
     // Overlay erreur — rendu en dernier pour être au-dessus de tout
     if let AppMode::Error(msg) = &app.app_mode {
-        draw_error_overlay(f, msg.clone(), f.area());
+        draw_error_overlay(f, msg.clone(), f.area(), app.theme);
     }
 }
 
@@ -54,7 +54,7 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
 }
 
 /// Panneau d'erreur centré, affiché par-dessus l'interface normale.
-fn draw_error_overlay(f: &mut Frame, msg: String, area: Rect) {
+fn draw_error_overlay(f: &mut Frame, msg: String, area: Rect, theme: &Theme) {
     // Calcule la hauteur selon le nombre de lignes du message
     let lines: Vec<&str> = msg.lines().collect();
     let inner_h = (lines.len() as u16).max(1);
@@ -71,8 +71,8 @@ fn draw_error_overlay(f: &mut Frame, msg: String, area: Rect) {
         .title(" ⚠  Erreur ")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(CATPPUCCIN_MOCHA.red))
-        .style(Style::default().bg(CATPPUCCIN_MOCHA.bg));
+        .border_style(Style::default().fg(theme.red))
+        .style(Style::default().bg(theme.bg));
 
     let inner = block.inner(popup_area);
     f.render_widget(block, popup_area);
@@ -88,13 +88,13 @@ fn draw_error_overlay(f: &mut Frame, msg: String, area: Rect) {
 
     let text: Vec<Line> = lines
         .iter()
-        .map(|l| Line::from(Span::styled(*l, Style::default().fg(CATPPUCCIN_MOCHA.fg))))
+        .map(|l| Line::from(Span::styled(*l, Style::default().fg(theme.fg))))
         .collect();
     let paragraph = Paragraph::new(text).wrap(Wrap { trim: false });
     f.render_widget(paragraph, chunks[0]);
 
     let hint = Paragraph::new("Appuyez sur Entrée ou Esc pour fermer")
-        .style(Style::default().fg(CATPPUCCIN_MOCHA.subtext0));
+        .style(Style::default().fg(theme.subtext0));
     f.render_widget(hint, chunks[1]);
 }
 
@@ -118,11 +118,11 @@ fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .title(" Mode de Connexion (Tab to switch) ")
-                .border_style(Style::default().fg(CATPPUCCIN_MOCHA.border))
+                .border_style(Style::default().fg(app.theme.border))
         )
         .select(app.connection_mode.index())
-        .style(Style::default().fg(CATPPUCCIN_MOCHA.subtext0))
-        .highlight_style(Style::default().bg(CATPPUCCIN_MOCHA.sky).fg(CATPPUCCIN_MOCHA.bg).add_modifier(Modifier::BOLD));
+        .style(Style::default().fg(app.theme.subtext0))
+        .highlight_style(Style::default().bg(app.theme.sky).fg(app.theme.bg).add_modifier(Modifier::BOLD));
     f.render_widget(tabs, area);
 }
 
@@ -131,9 +131,9 @@ fn draw_verbose_toggle(f: &mut Frame, app: &App, area: Rect) {
     let text = format!("{} Verbose (-v)", checkbox);
     
     let style = if app.verbose_mode {
-        Style::default().fg(CATPPUCCIN_MOCHA.green).add_modifier(Modifier::BOLD)
+        Style::default().fg(app.theme.green).add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(CATPPUCCIN_MOCHA.subtext0)
+        Style::default().fg(app.theme.subtext0)
     };
     
     let verbose = Paragraph::new(text)
@@ -143,7 +143,7 @@ fn draw_verbose_toggle(f: &mut Frame, app: &App, area: Rect) {
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .title(" Options (v to toggle) ")
-                .border_style(Style::default().fg(CATPPUCCIN_MOCHA.border))
+                .border_style(Style::default().fg(app.theme.border))
         );
     f.render_widget(verbose, area);
 }
@@ -181,21 +181,21 @@ fn draw_search_bar(f: &mut Frame, app: &mut App, area: Rect) {
             } else {
                 format!(" ✓ {} / {} servers match '{}' ", server_count, total_servers, app.search_query)
             };
-            return draw_search_with_results(f, area, &app.search_query, &title_text, server_count);
+            return draw_search_with_results(f, area, &app.search_query, &title_text, server_count, app.theme);
         };
         (text, " Search (press /) ".to_string())
     };
 
     let border_color = if app.is_searching {
-        CATPPUCCIN_MOCHA.sapphire
+        app.theme.sapphire
     } else {
-        CATPPUCCIN_MOCHA.border
+        app.theme.border
     };
     
     let text_color = if app.is_searching {
-        CATPPUCCIN_MOCHA.fg
+        app.theme.fg
     } else {
-        CATPPUCCIN_MOCHA.subtext0
+        app.theme.subtext0
     };
 
     let search = Paragraph::new(search_text)
@@ -210,15 +210,15 @@ fn draw_search_bar(f: &mut Frame, app: &mut App, area: Rect) {
     f.render_widget(search, area);
 }
 
-fn draw_search_with_results(f: &mut Frame, area: Rect, query: &str, title: &str, count: usize) {
+fn draw_search_with_results(f: &mut Frame, area: Rect, query: &str, title: &str, count: usize, theme: &Theme) {
     let border_color = if count > 0 {
-        CATPPUCCIN_MOCHA.green
+        theme.green
     } else {
-        CATPPUCCIN_MOCHA.red
+        theme.red
     };
     
     let search = Paragraph::new(query)
-        .style(Style::default().fg(CATPPUCCIN_MOCHA.fg))
+        .style(Style::default().fg(theme.fg))
         .block(
             Block::default()
                 .borders(Borders::ALL)
@@ -239,7 +239,7 @@ fn draw_tree(f: &mut Frame, app: &mut App, area: Rect) {
                 let id = format!("Group:{}", name);
                 let icon = if app.expanded_items.contains(&id) || !app.search_query.is_empty() { "📂" } else { "📁" }; 
                 Line::from(vec![
-                    Span::styled(format!("{} {}", icon, name), Style::default().fg(CATPPUCCIN_MOCHA.group_header).add_modifier(Modifier::BOLD)),
+                    Span::styled(format!("{} {}", icon, name), Style::default().fg(app.theme.group_header).add_modifier(Modifier::BOLD)),
                 ])
             },
             ConfigItem::Environment(g, name) => {
@@ -247,7 +247,7 @@ fn draw_tree(f: &mut Frame, app: &mut App, area: Rect) {
                 let icon = if app.expanded_items.contains(&id) || !app.search_query.is_empty() { "🌩️" } else { "☁️" };
                 Line::from(vec![
                     Span::raw("  "),
-                    Span::styled(format!("{} {}", icon, name), Style::default().fg(CATPPUCCIN_MOCHA.env_header)),
+                    Span::styled(format!("{} {}", icon, name), Style::default().fg(app.theme.env_header)),
                 ])
             },
             ConfigItem::Server(server) => {
@@ -260,7 +260,7 @@ fn draw_tree(f: &mut Frame, app: &mut App, area: Rect) {
                 };
                 Line::from(vec![
                     Span::raw(indent),
-                    Span::styled(format!("🖥️ {}", server.name), Style::default().fg(CATPPUCCIN_MOCHA.server_item)),
+                    Span::styled(format!("🖥️ {}", server.name), Style::default().fg(app.theme.server_item)),
                 ])
             },
         };
@@ -274,9 +274,9 @@ fn draw_tree(f: &mut Frame, app: &mut App, area: Rect) {
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .title(" Servers ")
-                .border_style(Style::default().fg(CATPPUCCIN_MOCHA.border))
+                .border_style(Style::default().fg(app.theme.border))
         )
-        .highlight_style(Style::default().bg(CATPPUCCIN_MOCHA.selection_bg).fg(CATPPUCCIN_MOCHA.selection_fg).add_modifier(Modifier::BOLD))
+        .highlight_style(Style::default().bg(app.theme.selection_bg).fg(app.theme.selection_fg).add_modifier(Modifier::BOLD))
         .highlight_symbol("▎ ");
     
     f.render_stateful_widget(list, area, &mut app.list_state);
@@ -287,7 +287,7 @@ fn draw_details(f: &mut Frame, app: &mut App, area: Rect) {
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .title(" Details ")
-        .border_style(Style::default().fg(CATPPUCCIN_MOCHA.border));
+        .border_style(Style::default().fg(app.theme.border));
 
     let visible_items = app.get_visible_items();
     let text = if let Some(item) = visible_items.get(app.selected_index) {
@@ -295,23 +295,23 @@ fn draw_details(f: &mut Frame, app: &mut App, area: Rect) {
              ConfigItem::Server(server) => {
                 let mut lines = vec![
                     Line::from(vec![
-                        Span::styled("Name: ", Style::default().add_modifier(Modifier::BOLD).fg(CATPPUCCIN_MOCHA.fg)),
+                        Span::styled("Name: ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
                         Span::raw(&server.name),
                     ]),
                     Line::from(vec![
-                        Span::styled("Host: ", Style::default().add_modifier(Modifier::BOLD).fg(CATPPUCCIN_MOCHA.fg)),
+                        Span::styled("Host: ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
                         Span::raw(&server.host),
                     ]),
                     Line::from(vec![
-                        Span::styled("User: ", Style::default().add_modifier(Modifier::BOLD).fg(CATPPUCCIN_MOCHA.fg)),
+                        Span::styled("User: ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
                         Span::raw(&server.user),
                     ]),
                     Line::from(vec![
-                        Span::styled("IdentityFile: ", Style::default().add_modifier(Modifier::BOLD).fg(CATPPUCCIN_MOCHA.fg)),
+                        Span::styled("IdentityFile: ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
                         Span::raw(&server.ssh_key),
                     ]),
                     Line::from(vec![
-                        Span::styled("SSH Options:", Style::default().add_modifier(Modifier::BOLD).fg(CATPPUCCIN_MOCHA.fg)),
+                        Span::styled("SSH Options:", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
                     ]),
                 ];
                 
@@ -319,7 +319,7 @@ fn draw_details(f: &mut Frame, app: &mut App, area: Rect) {
                 for option in &server.ssh_options {
                     lines.push(Line::from(vec![
                         Span::raw("  • "),
-                        Span::styled(option, Style::default().fg(CATPPUCCIN_MOCHA.subtext0)),
+                        Span::styled(option, Style::default().fg(app.theme.subtext0)),
                     ]));
                 }
                 
@@ -334,7 +334,7 @@ fn draw_details(f: &mut Frame, app: &mut App, area: Rect) {
 
     let paragraph = Paragraph::new(text)
         .block(block)
-        .style(Style::default().fg(CATPPUCCIN_MOCHA.fg))
+        .style(Style::default().fg(app.theme.fg))
         .wrap(Wrap { trim: true });
         
     f.render_widget(paragraph, area);
@@ -344,7 +344,7 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
     // Affiche le message temporaire (clipboard, erreur…) si présent
     if let Some((msg, _)) = &app.status_message {
         let paragraph = Paragraph::new(msg.as_str())
-            .style(Style::default().bg(CATPPUCCIN_MOCHA.selection_bg).fg(CATPPUCCIN_MOCHA.green));
+            .style(Style::default().bg(app.theme.selection_bg).fg(app.theme.green));
         f.render_widget(paragraph, area);
         return;
     }
@@ -357,6 +357,6 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
         "Navigate: ↑/↓ | Expand: Space/Enter | Search: / | Mode: Tab/1-3 | Verbose: v | y: Copy cmd | q: Quit"
     };
     let paragraph = Paragraph::new(text)
-        .style(Style::default().bg(CATPPUCCIN_MOCHA.selection_bg).fg(CATPPUCCIN_MOCHA.fg));
+        .style(Style::default().bg(app.theme.selection_bg).fg(app.theme.fg));
     f.render_widget(paragraph, area);
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -294,7 +294,7 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
     }
 
     let text = if app.is_searching {
-        "Search Mode: Type to filter | ESC: Cancel | Enter: Apply"
+        "Search Mode: Type to filter | ESC: Cancel | Ctrl+U: Clear | Enter: Apply"
     } else if !app.search_query.is_empty() {
         "Navigate: ↑/↓ | Clear: ESC | New search: / | Verbose: v | Enter: Connect | q: Quit"
     } else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,11 +5,11 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, List, ListItem, Paragraph, Wrap, Tabs},
+    widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph, Wrap, Tabs},
     Frame,
 };
 
-use crate::app::{App, ConfigItem};
+use crate::app::{App, AppMode, ConfigItem};
 use crate::ui::theme::CATPPUCCIN_MOCHA;
 
 pub fn draw(f: &mut Frame, app: &mut App) {
@@ -39,10 +39,66 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     
     // draw_status_bar(f, app, chunks[3]); -> Correct index
     draw_status_bar(f, app, chunks[3]);
+
+    // Overlay erreur — rendu en dernier pour être au-dessus de tout
+    if let AppMode::Error(msg) = &app.app_mode {
+        draw_error_overlay(f, msg.clone(), f.area());
+    }
 }
 
-fn draw_connection_mode_area(f: &mut Frame, app: &App, area: Rect) {
+/// Rectangle centré de taille fixe dans `area`.
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let x = area.x + area.width.saturating_sub(width) / 2;
+    let y = area.y + area.height.saturating_sub(height) / 2;
+    Rect::new(x, y, width.min(area.width), height.min(area.height))
+}
+
+/// Panneau d'erreur centré, affiché par-dessus l'interface normale.
+fn draw_error_overlay(f: &mut Frame, msg: String, area: Rect) {
+    // Calcule la hauteur selon le nombre de lignes du message
+    let lines: Vec<&str> = msg.lines().collect();
+    let inner_h = (lines.len() as u16).max(1);
+    // bordure (2) + titre (0 = inclus dans bordure) + contenu + hint (1) + marges (1)
+    let popup_h = inner_h + 5;
+    let popup_w = (msg.lines().map(|l| l.len()).max().unwrap_or(20) as u16 + 6).clamp(40, area.width.saturating_sub(4));
+
+    let popup_area = centered_rect(popup_w, popup_h, area);
+
+    // Efface la zone du popup
+    f.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .title(" ⚠  Erreur ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(CATPPUCCIN_MOCHA.red))
+        .style(Style::default().bg(CATPPUCCIN_MOCHA.bg));
+
+    let inner = block.inner(popup_area);
+    f.render_widget(block, popup_area);
+
+    // Splits inner: message + hint
     let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let text: Vec<Line> = lines
+        .iter()
+        .map(|l| Line::from(Span::styled(*l, Style::default().fg(CATPPUCCIN_MOCHA.fg))))
+        .collect();
+    let paragraph = Paragraph::new(text).wrap(Wrap { trim: false });
+    f.render_widget(paragraph, chunks[0]);
+
+    let hint = Paragraph::new("Appuyez sur Entrée ou Esc pour fermer")
+        .style(Style::default().fg(CATPPUCCIN_MOCHA.subtext0));
+    f.render_widget(hint, chunks[1]);
+}
+
+fn draw_connection_mode_area(f: &mut Frame, app: &App, area: Rect) {    let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
             Constraint::Percentage(70), // Tabs

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -64,7 +64,7 @@ fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
                 .title(" Mode de Connexion (Tab to switch) ")
                 .border_style(Style::default().fg(CATPPUCCIN_MOCHA.border))
         )
-        .select(app.connection_mode)
+        .select(app.connection_mode.index())
         .style(Style::default().fg(CATPPUCCIN_MOCHA.subtext0))
         .highlight_style(Style::default().bg(CATPPUCCIN_MOCHA.sky).fg(CATPPUCCIN_MOCHA.bg).add_modifier(Modifier::BOLD));
     f.render_widget(tabs, area);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -293,36 +293,77 @@ fn draw_details(f: &mut Frame, app: &mut App, area: Rect) {
     let text = if let Some(item) = visible_items.get(app.selected_index) {
         match item {
              ConfigItem::Server(server) => {
+                // Port : jaune si différent de 22
+                let port_style = if server.port != 22 {
+                    Style::default().fg(app.theme.yellow).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(app.theme.subtext0)
+                };
+
                 let mut lines = vec![
                     Line::from(vec![
-                        Span::styled("Name: ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                        Span::styled("Name:   ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
                         Span::raw(&server.name),
                     ]),
                     Line::from(vec![
-                        Span::styled("Host: ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                        Span::styled("Host:   ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
                         Span::raw(&server.host),
                     ]),
                     Line::from(vec![
-                        Span::styled("User: ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                        Span::styled("Port:   ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                        Span::styled(server.port.to_string(), port_style),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("User:   ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
                         Span::raw(&server.user),
                     ]),
                     Line::from(vec![
-                        Span::styled("IdentityFile: ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
-                        Span::raw(&server.ssh_key),
+                        Span::styled("Mode:   ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                        Span::styled(server.default_mode.to_string(), Style::default().fg(app.theme.sapphire)),
                     ]),
                     Line::from(vec![
-                        Span::styled("SSH Options:", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                        Span::styled("Key:    ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                        Span::raw(&server.ssh_key),
                     ]),
                 ];
-                
-                // Add each SSH option as a separate line with indentation
-                for option in &server.ssh_options {
+
+                // Jump host (mode Rebond)
+                if let Some(jump) = &server.jump_host {
+                    let jump_display = match &server.jump_user {
+                        Some(u) => format!("{}@{}", u, jump),
+                        None => jump.clone(),
+                    };
                     lines.push(Line::from(vec![
-                        Span::raw("  • "),
-                        Span::styled(option, Style::default().fg(app.theme.subtext0)),
+                        Span::styled("Jump:   ", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                        Span::styled(jump_display, Style::default().fg(app.theme.sky)),
                     ]));
                 }
-                
+
+                // Bastion host
+                if let Some(bhost) = &server.bastion_host {
+                    let bastion_display = match &server.bastion_user {
+                        Some(u) => format!("{}@{}", u, bhost),
+                        None => bhost.clone(),
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled("Bastion:", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                        Span::raw(" "),
+                        Span::styled(bastion_display, Style::default().fg(app.theme.sky)),
+                    ]));
+                }
+
+                if !server.ssh_options.is_empty() {
+                    lines.push(Line::from(vec![
+                        Span::styled("Options:", Style::default().add_modifier(Modifier::BOLD).fg(app.theme.fg)),
+                    ]));
+                    for option in &server.ssh_options {
+                        lines.push(Line::from(vec![
+                            Span::raw("  • "),
+                            Span::styled(option, Style::default().fg(app.theme.subtext0)),
+                        ]));
+                    }
+                }
+
                 lines
              },
              ConfigItem::Group(name) => vec![Line::from(format!("Group: {}", name))],

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,6 +1,8 @@
 use std::sync::LazyLock;
 use ratatui::style::Color;
 
+use crate::config::ThemeVariant;
+
 pub struct Theme {
     #[allow(dead_code)]
     pub bg: Color,
@@ -23,10 +25,12 @@ pub struct Theme {
     pub subtext0: Color,
 }
 
-pub static CATPPUCCIN_MOCHA: LazyLock<Theme> = LazyLock::new(|| {
-    let mocha = catppuccin::PALETTE.mocha;
-    let colors = mocha.colors;
-    
+fn to_ratatui(c: catppuccin::Color) -> Color {
+    Color::Rgb(c.rgb.r, c.rgb.g, c.rgb.b)
+}
+
+fn make_theme(flavor: catppuccin::Flavor) -> Theme {
+    let colors = flavor.colors;
     Theme {
         bg: to_ratatui(colors.base),
         fg: to_ratatui(colors.text),
@@ -45,8 +49,26 @@ pub static CATPPUCCIN_MOCHA: LazyLock<Theme> = LazyLock::new(|| {
         sapphire: to_ratatui(colors.sapphire),
         subtext0: to_ratatui(colors.subtext0),
     }
-});
+}
 
-fn to_ratatui(c: catppuccin::Color) -> Color {
-    Color::Rgb(c.rgb.r, c.rgb.g, c.rgb.b)
+pub static CATPPUCCIN_LATTE: LazyLock<Theme> =
+    LazyLock::new(|| make_theme(catppuccin::PALETTE.latte));
+
+pub static CATPPUCCIN_FRAPPE: LazyLock<Theme> =
+    LazyLock::new(|| make_theme(catppuccin::PALETTE.frappe));
+
+pub static CATPPUCCIN_MACCHIATO: LazyLock<Theme> =
+    LazyLock::new(|| make_theme(catppuccin::PALETTE.macchiato));
+
+pub static CATPPUCCIN_MOCHA: LazyLock<Theme> =
+    LazyLock::new(|| make_theme(catppuccin::PALETTE.mocha));
+
+/// Retourne le thème statique correspondant à la variante choisie.
+pub fn get_theme(variant: ThemeVariant) -> &'static Theme {
+    match variant {
+        ThemeVariant::Latte => &*CATPPUCCIN_LATTE,
+        ThemeVariant::Frappe => &*CATPPUCCIN_FRAPPE,
+        ThemeVariant::Macchiato => &*CATPPUCCIN_MACCHIATO,
+        ThemeVariant::Mocha => &*CATPPUCCIN_MOCHA,
+    }
 }

--- a/tests/parse_full_config.rs
+++ b/tests/parse_full_config.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use sushi::config::Config;
+    use sushi::config::{Config, ConnectionMode};
     use std::path::PathBuf;
 
     #[test]
@@ -21,7 +21,7 @@ mod tests {
         let nextcloud = resolved.iter().find(|s| s.name == "nextcloud").expect("nextcloud found");
         assert_eq!(nextcloud.host, "192.168.1.13");
         assert_eq!(nextcloud.user, "root"); // server override
-        assert_eq!(nextcloud.default_mode, "direct");
+        assert_eq!(nextcloud.default_mode, ConnectionMode::Direct);
         
         // Find db-01
         let db01 = resolved.iter().find(|s| s.name == "db-01").expect("db-01 found");
@@ -32,7 +32,7 @@ mod tests {
         // Find internal-nas
         let nas = resolved.iter().find(|s| s.name == "internal-nas").expect("internal-nas found");
         assert_eq!(nas.user, "root"); // server override
-        assert_eq!(nas.default_mode, "bastion");
+        assert_eq!(nas.default_mode, ConnectionMode::Bastion);
         // Bastion should be inherited from defaults
         assert_eq!(nas.bastion_host.as_deref().unwrap(), "bastion.example.com");
         assert_eq!(nas.bastion_user.as_deref().unwrap(), "bastion");


### PR DESCRIPTION
### ✨ New Features
- **`ConnectionMode` enum** — replaces magic strings throughout the codebase.
- **CLI via `clap`** — `--direct`, `--rebond`, `--bastion`, `--user`, `--port`, `--key`, `--config`, `--verbose`.
- **`use_system_ssh_config`** — opt in to `~/.ssh/config` (ControlMaster, aliases…).
- **Clipboard** (`y`) — copy the SSH command via `arboard`.
- **`Ctrl+U`** — clear search query in search mode.
- **State persistence** — expanded groups saved to `~/.sushi_state.json`.
- **In-TUI error screen** — `AppMode::Error` overlay, dismissed with `Enter`/`Esc`/`q`.
- **Configurable Catppuccin theme** — `defaults.theme: latte | frappe | macchiato | mocha`.
- **Enriched detail pane** — port (yellow if ≠ 22), mode, jump host, bastion host.
- **`examples/full_config.yaml`** — fully documented reference.

### ⚡ Improvements
- `App::new()` returns `Result<Self, ConfigError>`.
- `get_visible_items()` cached with dirty flag.
- `build_ssh_args()` extracted as pure testable function.

### 🧪 Tests
22 tests, 0 failures.

### 📝 Docs
- `CHANGELOG.md` added.
- `README.md` updated.

**Tag**: `v0.4.0`