### PR TITLE
ci: add Nix flake check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,29 @@ jobs:
       - name: Check (MSRV)
         run: cargo +1.88 check --all-targets
 
+  nix:
+    name: Nix flake
+    runs-on: ubuntu-latest
+    needs: [preflight]
+    if: needs.preflight.outputs.skip != 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check flake
+        run: nix flake check --print-build-logs
+
+      - name: Build package
+        run: nix build --print-build-logs .
+
   megalinter:
     name: MegaLinter
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ wget https://github.com/yatoub/susshi/releases/latest/download/susshi-macos-amd6
 
 # Arch Linux
 paru -S susshi-bin
+
+# NixOS / Nix (flakes)
+nix run github:yatoub/susshi
 ```
 
 For DEB/RPM packages see the [releases page](https://github.com/yatoub/susshi/releases/latest).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,16 @@ Get up and running with susshi in under 5 minutes.
 === "DEB / RPM"
     Download from the [releases page](https://github.com/yatoub/susshi/releases/latest).
 
+=== "NixOS / Nix (flakes)"
+    ```bash
+    nix run github:yatoub/susshi
+    ```
+
+    Or add it as a flake input to your NixOS/home-manager config:
+    ```nix
+    inputs.susshi.url = "github:yatoub/susshi";
+    ```
+
 Verify:
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,11 @@
             lockFile = ./Cargo.lock;
           };
 
+          # Unit tests are exercised by the "Tests" CI job; skip them here since
+          # some rely on FHS paths (e.g. /usr/bin/true) unavailable in the Nix
+          # build sandbox.
+          doCheck = false;
+
           nativeBuildInputs = [ pkgs.pkg-config ];
           buildInputs = [ pkgs.openssl ]
             ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [


### PR DESCRIPTION
## Summary
- Adds a `nix` job to CI that runs `nix flake check` and `nix build .` against the `flake.nix` added in #147, so the flake's build correctness is verified automatically (no local Nix install available to test it manually).

## Test plan
- [ ] Confirm the new `Nix flake` job passes in this PR's checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)