### PR TITLE
fix: build x86_64/aarch64 glibc binaries on ubuntu-22.04, not -latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # ubuntu-22.04 (not -latest) to match release.yml's glibc-compat
+          # build environment — see the comment there for why.
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             openssl_mode: system
           - os: ubuntu-latest
@@ -264,7 +266,7 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             openssl_mode: system
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             openssl_mode: system
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # Built on an older Ubuntu LTS (older glibc) so the resulting binary
+          # runs on older distros too: glibc is forward-compatible only, so a
+          # binary linked against ubuntu-latest's glibc (24.04 -> 2.39) fails
+          # with "GLIBC_2.39 not found" on e.g. Debian 12 (glibc 2.36).
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             binary_name: susshi
             asset_name: susshi-linux-x86_64
@@ -61,7 +65,8 @@ jobs:
             binary_name: susshi
             asset_name: susshi-macos-apple-silicon
             openssl_mode: system
-          - os: ubuntu-24.04-arm
+          # Same glibc-compat reasoning as the x86_64-unknown-linux-gnu entry above.
+          - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             binary_name: susshi
             asset_name: susshi-linux-aarch64
@@ -101,7 +106,11 @@ jobs:
 
   build-deb:
     name: DEB packages
-    runs-on: ubuntu-latest
+    # ubuntu-22.04 (older glibc) so the amd64 .deb runs on older glibc distros
+    # (e.g. Debian 12 ships glibc 2.36, ubuntu-latest/24.04 links against 2.39).
+    # The arm64 .deb is cross-compiled via `cross`'s own Docker image, so its
+    # glibc baseline is unaffected by the host runner OS.
+    runs-on: ubuntu-22.04
     timeout-minutes: 50
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Fixes a reported failure on a fresh Debian 12 install via the new APT repo:

```
root@test:~# susshi -V
susshi: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by susshi)
```

Root cause: `build-deb` and the `build` matrix's glibc-linked Linux entries (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`) run on `ubuntu-latest`, which is Ubuntu 24.04 (glibc 2.39). glibc symbol versioning is forward-compatible only — a binary linked against 2.39 cannot run on an older glibc. Debian 12 (bookworm, current stable) ships glibc 2.36.

Fix: build those targets on `ubuntu-22.04` (glibc 2.35) instead, which runs fine on both Debian 12 and Ubuntu 24.04. Applied to both `release.yml` (the actual shipped artifacts) and `ci.yml`'s cross-platform matrix (so CI catches glibc regressions going forward, on the same baseline as releases).

Not affected:
- The arm64 `.deb` — cross-compiled via `cross`'s own Docker image, independent of the host runner's glibc.
- The musl static binary (`susshi-linux-x86_64-static`) — statically linked, no glibc dependency at all. This remains the safest fallback if a compat issue like this recurs.

## Test plan
- [ ] Merge and wait for the next release
- [ ] `apt install susshi` on a fresh Debian 12 container/VM, confirm `susshi -V` runs
- [ ] Direct-download `susshi-linux-x86_64` on the same box, confirm it also runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)