### PR TITLE
fix: resolve dependencies in arm64 DEB smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           docker run --rm --platform linux/arm64 \
             -v "${{ github.workspace }}/target/debian:/debs:ro" \
             debian:bookworm-slim \
-            bash -c "dpkg -i /debs/susshi_*_arm64.deb && susshi --version"
+            bash -c "apt-get update && apt-get install -y /debs/susshi_*_arm64.deb && susshi --version"
 
       - name: Upload to GitHub Release
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de  # v2


### PR DESCRIPTION
## Summary

The `workflow_dispatch` re-publish of `v0.20.0` (triggered to pick up the glibc-compat fix in #153) failed in `build-deb`, on the newly added arm64 smoke test:

```
dpkg: dependency problems prevent configuration of susshi:
 susshi depends on openssh-client; however:
   Package openssh-client is not installed.
```

`dpkg -i` doesn't resolve dependencies. The amd64 smoke test happens to work because it runs directly on the CI runner, which already has `openssh-client` preinstalled. The arm64 smoke test runs inside a bare `debian:bookworm-slim` container via QEMU, which has nothing preinstalled — so the missing dependency actually surfaces there.

## Fix
Use `apt-get install -y <path-to-deb>` instead of `dpkg -i`, which resolves and installs declared dependencies (`openssh-client`) from the container's package index.

## Test plan
- [ ] Merge, then re-trigger `release.yml` via `workflow_dispatch` for tag `v0.20.0` again to confirm `build-deb` passes and the fixed amd64 `.deb` finally gets published

🤖 Generated with [Claude Code](https://claude.com/claude-code)