### PR TITLE
fix: stop caching build-rpm's target/ dir, fixing missing man page on re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,14 +295,20 @@ jobs:
       - name: Install build dependencies
         run: dnf install -y rust cargo openssl-devel zlib-devel pkgconf-pkg-config rpm-build rpmdevtools git
 
-      - name: Cache Cargo registry and build artifacts
+      # Only the Cargo registry is cached, not the build's target/ dir: build.rs
+      # writes the man page to a path relative to the source checkout (not
+      # CARGO_TARGET_DIR), which rpmbuild re-extracts fresh on every run at a
+      # deterministic path. Caching target/ across runs let cargo see a fingerprint
+      # match and skip re-running build.rs, silently omitting the man page from
+      # the fresh checkout (surfaced when re-running release.yml for the same tag
+      # with an unchanged Cargo.lock — an exact cache-key hit).
+      - name: Cache Cargo registry
         uses: actions/cache@v6
         with:
           path: |
             /github/home/.cargo/registry/index
             /github/home/.cargo/registry/cache
             /github/home/.cargo/git/db
-            /github/home/cargo-target
           key: fedora-rpm-x86_64-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             fedora-rpm-x86_64-
@@ -323,7 +329,6 @@ jobs:
         env:
           OPENSSL_NO_VENDOR: "1"
           LIBZ_SYS_USE_PKG_CONFIG: "1"
-          CARGO_TARGET_DIR: /github/home/cargo-target
         run: rpmbuild -ba susshi.spec
 
       - name: Smoke test


### PR DESCRIPTION
## Summary

The `workflow_dispatch` re-publish of `v0.20.0` (to pick up #153/#154's fixes) failed in `build-rpm`:

```
+ install -Dm0644 target/man/susshi.1 /github/home/rpmbuild/BUILD/.../BUILDROOT/usr/share/man/man1/susshi.1
install: cannot stat 'target/man/susshi.1': No such file or directory
```

`cargo build` itself reported "Finished ... in 0.14s" — suspiciously fast, meaning it didn't actually rebuild anything.

## Root cause

`build-rpm` redirects `CARGO_TARGET_DIR` to `/github/home/cargo-target`, cached across runs via `actions/cache` keyed only on `hashFiles('Cargo.lock')`. But `build.rs` writes the man page to `target/man/` **relative to the source checkout**, not `CARGO_TARGET_DIR` — and rpmbuild re-extracts the source tarball fresh, at a version-deterministic path, on every single run (this directory itself is never cached).

- On a cache **miss** (first build for a given `Cargo.lock`), this worked by accident: `build.rs` ran, wrote `target/man/susshi.1` into the fresh checkout, and the `CARGO_TARGET_DIR` cache was irrelevant.
- On a cache **hit** — which only happens when re-running `release.yml` for a tag whose `Cargo.lock` hasn't changed, exactly the `workflow_dispatch` re-publish scenario used to land #153/#154's fixes — cargo saw a fingerprint match from the previous run's `CARGO_TARGET_DIR` and skipped re-executing `build.rs` entirely, so the fresh checkout's `target/man/susshi.1` was never created.

This bug was always latent; it just never had an opportunity to fire before, since every prior `build-rpm` run was a first-time build for a new `Cargo.lock`.

## Fix

Only cache the Cargo registry (the actually-slow part), and drop the `CARGO_TARGET_DIR` override so cargo builds into the default `target/` dir — right where `build.rs` already writes the man page. This matches how the DEB build (`cargo-deb`, no `CARGO_TARGET_DIR` override) already works safely.

## Test plan
- [ ] Merge, then re-trigger `release.yml` via `workflow_dispatch` for `v0.20.0` again — confirm `build-rpm` succeeds and the man page installs correctly
- [ ] Confirm `publish-rpm` then runs and the RPM repo is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)