### PR TITLE
fix: run publish-apt/publish-rpm on workflow_dispatch re-publish too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build-deb]
-    if: github.event_name == 'push'
+    # Also run on a manual re-publish (workflow_dispatch): that's precisely
+    # how a broken .deb already served by the APT repo gets fixed.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     concurrency:
       group: gh-pages-apt
       cancel-in-progress: false
@@ -367,7 +369,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build-rpm]
-    if: github.event_name == 'push'
+    # Also run on a manual re-publish (workflow_dispatch): that's precisely
+    # how a broken RPM already served by the repo gets fixed.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     concurrency:
       group: gh-pages-rpm
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

The `workflow_dispatch` re-publish of `v0.20.0` (used to land the glibc fix from #153 and the RPM man-page fix from #155) succeeded, but `publish-apt` and `publish-rpm` were **skipped**:

```
Publish APT repository    skipped
Publish RPM repository    skipped
```

Both jobs are gated on `if: github.event_name == 'push'`. The rebuilt binaries/.deb/.rpm made it onto the GitHub Release (those upload steps aren't gated), but the APT/RPM repos on `gh-pages` kept serving the previously broken `.deb`/`.rpm` — meaning `apt install susshi` / `dnf install susshi` were still broken even after the "fixed" release run completed successfully.

## Fix
Allow `publish-apt`/`publish-rpm` to also run on `workflow_dispatch`, since that's exactly the scenario where a previously-published broken package needs fixing. `update-pkgbuild`/`cleanup-branches` stay `push`-only — they commit to master and aren't meaningful to rerun manually.

## Test plan
- [ ] Merge, then re-trigger `release.yml` via `workflow_dispatch` for `v0.20.0` one more time
- [ ] Confirm `publish-apt` and `publish-rpm` actually run (not skipped) this time
- [ ] `apt update && apt install susshi` on a fresh Debian 12 box, confirm `susshi -V` finally works

🤖 Generated with [Claude Code](https://claude.com/claude-code)