### PR TITLE
fix: make publish-apt/publish-rpm idempotent, fix their failure notifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,10 @@ jobs:
           fi
 
           aptly repo create -distribution=stable -component=main susshi || true
-          aptly repo add susshi debs/*.deb
+          # -force-replace: re-publishing the same version (e.g. a workflow_dispatch
+          # re-run to fix a broken build) must overwrite the existing package
+          # instead of erroring out with "conflict in package".
+          aptly repo add -force-replace susshi debs/*.deb
 
           if aptly publish list | grep -q stable; then
             aptly publish update -gpg-key="$KEYID" -batch stable
@@ -255,7 +258,7 @@ jobs:
       - name: Commit and push to gh-pages
         working-directory: gh-pages-checkout
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -271,10 +274,11 @@ jobs:
         if: failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh issue create \
+            --repo "${{ github.repository }}" \
             --title "APT repo publish failed for $TAG" \
             --label "ci-failure" \
             --body "publish-apt failed on release $TAG. Run: $RUN_URL"
@@ -433,7 +437,7 @@ jobs:
       - name: Commit and push to gh-pages
         working-directory: gh-pages-checkout
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -449,10 +453,11 @@ jobs:
         if: failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh issue create \
+            --repo "${{ github.repository }}" \
             --title "RPM repo publish failed for $TAG" \
             --label "ci-failure" \
             --body "publish-rpm failed on release $TAG. Run: $RUN_URL"


### PR DESCRIPTION
## Summary

After #156 made `publish-apt`/`publish-rpm` run on `workflow_dispatch`, the next re-publish of `v0.20.0` hit a new failure:

```
ERROR: unable to add local repo: local repo with name susshi already exists
[!] Unable to add package to repo susshi_0.20.0-1_amd64: conflict in package
[!] Unable to add package to repo susshi_0.20.0-1_arm64: conflict in package
ERROR: some files failed to be added
```

`aptly repo add` refuses to re-add a package version that's already present in the repo — which is exactly what happens when re-running `release.yml` to fix a broken build under the same tag. Fixed with `aptly repo add -force-replace`.

The job's own failure-notification step (added earlier for observability) then also failed instead of surfacing the real error:

```
TAG: master
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Two bugs there:
- `TAG` used `github.ref_name`, which for `workflow_dispatch` is the branch the workflow ran from (`master`), not the tag passed via the `tag` input. Switched to `github.event.inputs.tag || github.ref_name`, matching the fallback already used elsewhere in this workflow.
- `gh issue create` implicitly detects the repo via git, but `publish-apt`/`publish-rpm` never check out the main repo at the workspace root (only `gh-pages`, into a `gh-pages-checkout` subdirectory) — so there's no `.git` for it to find. Added `--repo "${{ github.repository }}"` explicitly.

`update-pkgbuild` and `aur-publish.yml`'s notifiers were checked and are unaffected (they already checkout the main repo at root / already resolve TAG correctly).

## Test plan
- [ ] Merge, then re-trigger `release.yml` via `workflow_dispatch` for `v0.20.0` once more
- [ ] Confirm `publish-apt` and `publish-rpm` both succeed this time (not just "not skipped")
- [ ] `apt update && apt install susshi` on a fresh Debian 12 box, confirm it finally works

🤖 Generated with [Claude Code](https://claude.com/claude-code)