### PR TITLE
fix: aptly publish update needs -force-overwrite to actually refresh pool/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,12 @@ jobs:
           aptly repo add -force-replace susshi debs/*.deb
 
           if aptly publish list | grep -q stable; then
-            aptly publish update -gpg-key="$KEYID" -batch stable
+            # -force-overwrite: repo add -force-replace only swaps the package in
+            # aptly's local repo metadata. Without this flag, `publish update` still
+            # leaves the already-published pool/ file untouched when the
+            # version+arch key is unchanged, silently serving stale package bytes
+            # even though the Packages index now describes the new one.
+            aptly publish update -force-overwrite -gpg-key="$KEYID" -batch stable
           else
             aptly publish repo -gpg-key="$KEYID" -batch -distribution=stable susshi
           fi


### PR DESCRIPTION
## Summary

Even after #157's `-force-replace` fix landed and a fresh `apt install susshi` was tested, users still got:

```
E: Failed to fetch https://yatoub.github.io/susshi/apt/pool/main/s/susshi/susshi_0.20.0-1_amd64.deb
   File has unexpected size (2032052 != 2033592). Mirror sync in progress?
```

Initially suspected CDN staleness, but confirmed via `gh-pages` git history that this was a real origin-side inconsistency, not caching: the committed `.deb` in `apt/pool/...` was still 2032052 bytes while the `Packages` index already declared `Size: 2033592`, and that pool file had literally never been touched since the very first publish commit — despite multiple `-force-replace` re-publishes since.

## Root cause

`aptly repo add -force-replace` only swaps the package entry in aptly's **local repo metadata**. `aptly publish update` sees the same version+arch key as already published and skips rewriting the pool file — so the `Packages` index gets correctly regenerated with the new size, but the file it points to is never actually overwritten on disk. Confirmed via aptly's own docs: this needs the separate publish-side `-force-overwrite` flag ("overwrite packages files in the pool even if content is different").

## Fix
Add `-force-overwrite` to `aptly publish update`.

Also investigated and ruled out a second suspected bug (the sync step copying aptly's internal content-addressed pool cache into gh-pages) — verified via git history that it only adds harmless hash-named files in separate subdirectories, not overwriting the public pool path. Left as-is.

## Test plan
- [ ] Merge, then re-trigger `release.yml` via `workflow_dispatch` for `v0.20.0` once more
- [ ] Confirm the committed `apt/pool/.../susshi_0.20.0-1_amd64.deb` size now matches the `Packages` index
- [ ] `apt update && apt install susshi` on a fresh Debian 12 box — confirm it finally installs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)