### PR TITLE
fix: stop mixing aptly's internal pool into the served apt/pool tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,9 +229,16 @@ jobs:
       - name: Build APT repo with aptly
         run: |
           mkdir -p ~/.aptly
-          if [ -d gh-pages-checkout/apt/db ]; then
-            cp -r gh-pages-checkout/apt/db ~/.aptly/db
-            cp -r gh-pages-checkout/apt/pool ~/.aptly/pool
+          # aptly's internal state (repo db + its own content-addressed package
+          # pool) lives under apt/_state/, separate from apt/dists and apt/pool
+          # (the tree actually served to apt clients, regenerated fresh below).
+          # They must never share a directory: merging them here and copying
+          # the merged tree back at the end of the job would silently
+          # re-overwrite the freshly published pool/ file with a stale one on
+          # every subsequent run, regardless of any aptly -force-* flag.
+          if [ -d gh-pages-checkout/apt/_state/db ]; then
+            cp -r gh-pages-checkout/apt/_state/db ~/.aptly/db
+            cp -r gh-pages-checkout/apt/_state/pool ~/.aptly/pool
           fi
 
           aptly repo create -distribution=stable -component=main susshi || true
@@ -254,11 +261,10 @@ jobs:
       - name: Sync published repo into gh-pages
         run: |
           rm -rf gh-pages-checkout/apt
-          mkdir -p gh-pages-checkout/apt
+          mkdir -p gh-pages-checkout/apt gh-pages-checkout/apt/_state
           cp -r ~/.aptly/public/* gh-pages-checkout/apt/
-          mkdir -p gh-pages-checkout/apt/db gh-pages-checkout/apt/pool
-          cp -r ~/.aptly/db/* gh-pages-checkout/apt/db/
-          cp -r ~/.aptly/pool/* gh-pages-checkout/apt/pool/
+          cp -r ~/.aptly/db gh-pages-checkout/apt/_state/db
+          cp -r ~/.aptly/pool gh-pages-checkout/apt/_state/pool
 
       - name: Commit and push to gh-pages
         working-directory: gh-pages-checkout


### PR DESCRIPTION
## Summary

`apt install susshi` still fetched a wrong-size, stale `.deb` even after #158's `-force-overwrite` fix landed and a fresh `release.yml` run completed successfully:

```
Err:15 https://yatoub.github.io/susshi/apt stable/main amd64 susshi amd64 0.20.0-1
  File has unexpected size (2032052 != 2033504). Mirror sync in progress?
```

Traced via gh-pages git history: `apt/pool/main/s/susshi/susshi_0.20.0-1_amd64.deb` has been **exactly** 2032052 bytes since the very first publish commit (`c01d643`), completely unchanged across every subsequent republish — regardless of `-force-replace` or `-force-overwrite`, both of which were confirmed (via job logs) to run and report success (`"Publish for local repo ./stable [amd64, arm64] ... has been successfully updated."`).

## Root cause

Not an aptly flag problem at all — our own sync script was self-poisoning the served tree. It persisted aptly's *internal* state (repo db + its own content-addressed package pool) at `gh-pages-checkout/apt/db` and `apt/pool`, the **same path** used for the tree actually served to apt clients:

1. `cp -r ~/.aptly/public/* .../apt/` correctly wrote the freshly-published `.deb` (right bytes) into `apt/pool/main/s/susshi/...`.
2. The job then also ran `cp -r ~/.aptly/pool/* .../apt/pool/` — merging aptly's *internal* pool into the same `apt/pool` directory, which (via the restore step) still contained a copy of the *original* `.deb` from the first-ever publish.
3. That stale file gets faithfully restored into `~/.aptly/pool` at the start of the next run, and the job's own final sync step re-overwrites the freshly-correct file from step 1 with it. Every single run.

## Fix

Store aptly's internal db/pool under a separate `apt/_state/` subdirectory, never merged into `apt/dists`/`apt/pool` (now written from `~/.aptly/public/` alone and left untouched afterwards). Self-healing — the next `publish-apt` run wipes and rebuilds `apt/` entirely, no manual gh-pages cleanup needed.

## Test plan
- [ ] Merge, then re-trigger `release.yml` via `workflow_dispatch` for `v0.20.0`
- [ ] Confirm `apt/pool/.../susshi_0.20.0-1_amd64.deb` on gh-pages finally matches the `Packages` index size
- [ ] `apt update && apt install susshi` on the Debian 12 test VM — confirm it installs cleanly this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)