### PR TITLE
fix: refresh stale susshi-bin AUR checksum and fix re-publish gating

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -30,10 +30,16 @@ jobs:
     permissions:
       contents: read
       issues: write
+    # Also run when the completed Release workflow was itself a manual
+    # workflow_dispatch re-publish: a re-publish can rebuild the binary
+    # (overwrite: true on the upload step) with different bytes, which
+    # otherwise leaves the AUR package's checksum stale until the next
+    # tagged release.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push')
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch'))
 
     steps:
       - name: Resolve version to publish
@@ -113,10 +119,16 @@ jobs:
     permissions:
       contents: read
       issues: write
+    # Also run when the completed Release workflow was itself a manual
+    # workflow_dispatch re-publish: a re-publish can rebuild the binary
+    # (overwrite: true on the upload step) with different bytes, which
+    # otherwise leaves the AUR package's checksum stale until the next
+    # tagged release.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push')
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch'))
 
     steps:
       - name: Resolve version to publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,7 +599,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build]
-    if: github.event_name == 'push'
+    # Also run on a manual re-publish (workflow_dispatch): a re-publish can
+    # rebuild binaries (overwrite: true on the upload step) without the
+    # bytes being reproducible, which leaves PKGBUILD's checksums stale.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
       issues: write

--- a/PKGBUILD.bin
+++ b/PKGBUILD.bin
@@ -1,6 +1,6 @@
 pkgname=susshi-bin
 pkgver=0.20.0
-pkgrel=1
+pkgrel=2
 pkgdesc='modern, terminal-based SSH connection manager (pre-built binary)'
 url='https://github.com/yatoub/susshi'
 license=('MIT')
@@ -11,7 +11,7 @@ conflicts=('susshi')
 source=("https://github.com/yatoub/susshi/archive/refs/tags/v${pkgver}.tar.gz")
 source_x86_64=("susshi-${pkgver}-linux-x86_64::https://github.com/yatoub/susshi/releases/download/v${pkgver}/susshi-linux-x86_64")
 b2sums=('027b8c7ed5686f0db424e76f8422b2894755a1bb285415b4c3c4536a8afe37710e95d6c042222d3cb5602994dc79931ae8725cb13058126f52cda3855cc636ff')
-b2sums_x86_64=('968711cf0b74af915c18c53e4c27ccd3458aa65a27d859c179e23fa8b67a5942bee5f0e7f92eb9f6b0a043b504ec524f3f5b18baad7189a5c66ee1a3b46528f2')
+b2sums_x86_64=('0b6b40ba109eed42d0d8f070b462f10f8f0696a6a77fcaffa5f5021070a5ad8f62f4e21deefb357a20f725d4f2072f1898fac6e3f3b72ad7e1fba98d92b64261')
 
 package() {
     install -Dm0755 "susshi-${pkgver}-linux-x86_64" "$pkgdir/usr/bin/susshi"


### PR DESCRIPTION
## Summary
- `PKGBUILD.bin`'s `b2sums_x86_64` for v0.20.0 was stale: the released `susshi-linux-x86_64` binary was rebuilt via a `workflow_dispatch` re-publish (see #156) *after* the checksum was committed, and neither `update-pkgbuild` nor `aur-publish.yml` re-ran because both were gated to `push`-only events. Result: `paru -S susshi-bin` fails with a b2sum mismatch.
- Refreshed `b2sums_x86_64` to match the binary currently on the `v0.20.0` GitHub Release (verified locally), bumped `pkgrel` to 2.
- Widened `update-pkgbuild` (release.yml) and both `aur-source`/`aur-bin` jobs (aur-publish.yml) to also run on `workflow_dispatch` re-publishes, mirroring the fix already applied to `publish-apt`/`publish-rpm` in #156. Prevents this from recurring on the next manual re-publish.

## Test plan
- [ ] Merge, confirm `update-pkgbuild` job runs cleanly on `push`
- [ ] Confirm `aur-publish.yml`'s `aur-bin` job runs automatically after merge (via workflow_run) and pushes the corrected checksum to AUR
- [ ] `paru -S susshi-bin` succeeds after AUR sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtrXTQFaWyqqQcg3gRuBSM