### PR TITLE
chore: release v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.20.1] — 2026-07-19
+
+### Fixed
+
+- Refresh stale susshi-bin AUR checksum and fix re-publish gating ([#162](https://github.com/yatoub/susshi/pull/162))
+
+
 ## [0.20.0] — 2026-07-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "susshi"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "susshi"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal SSH manager with YAML inventories, multi-hop jump hosts, Wallix bastion, tunnels, SCP, and Catppuccin TUI"


### PR DESCRIPTION



## 🤖 New release

* `susshi`: 0.20.0 -> 0.20.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.1] — 2026-07-19

### Fixed

- Refresh stale susshi-bin AUR checksum and fix re-publish gating ([#162](https://github.com/yatoub/susshi/pull/162))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).