### PR TITLE
fix: build cargo-deb/cross from source in build-deb, not prebuilt binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,15 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
 
+      # Built from source (not taiki-e/install-action's prebuilt binaries):
+      # this job runs on ubuntu-22.04 (glibc 2.36) for the amd64 .deb's
+      # glibc-compat baseline (see the runs-on comment above), but prebuilt
+      # cargo-deb releases are linked against a newer glibc (GLIBC_2.39) and
+      # fail to even run here.
       - name: Install cargo-deb and cross
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deb,cross
+        run: |
+          cargo install cargo-deb
+          cargo install cross
 
       - name: Install system OpenSSL (amd64)
         run: |


### PR DESCRIPTION
## Summary
The v0.21.0 release run's `DEB packages` job failed:

```
info: cargo-deb installed at /home/runner/.cargo/bin/cargo-deb
+ cargo-deb deb --version
cargo-deb: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by cargo-deb)
```

Cause: a recent CI-performance PR swapped `cargo install cargo-deb`/`cargo install cross` for `taiki-e/install-action`'s prebuilt binaries in `build-deb`. That job intentionally runs on `ubuntu-22.04` (glibc 2.36) rather than `ubuntu-latest`, specifically so the amd64 `.deb` it produces stays installable on older-glibc distros (see the `runs-on` comment in the job). The prebuilt `cargo-deb` release binary is linked against glibc 2.39, so it can't even run on that image.

Fix: revert to building `cargo-deb`/`cross` from source via `cargo install` in this job only. `ci.yml`'s `coverage` job keeps the prebuilt-binary install for `cargo-llvm-cov` since it runs on `ubuntu-latest` (new enough glibc) — confirmed green in the last few CI runs.

## Test plan
- [x] `yaml.safe_load` on the changed file
- [ ] After merge, re-trigger the v0.21.0 release via `workflow_dispatch` (`tag: v0.21.0`) to confirm `build-deb` succeeds — this pulls the workflow definition from `master` (with this fix) while still checking out the `v0.21.0` source tag, which is exactly what the re-publish path in this pipeline is designed for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtJyrXncn5qqjfLBQ38HAx