### PR TITLE
fix: resolve AUR publish tag explicitly instead of inferring from workflow_run

### DIFF
--- a/.github/actions/resolve-release-tag/action.yml
+++ b/.github/actions/resolve-release-tag/action.yml
@@ -1,22 +1,12 @@
 name: Resolve release tag
 description: >
-  Resolves the version tag to publish, either from a workflow_dispatch
-  input or by matching the triggering workflow_run's head_sha against
-  remote tags (head_branch is always a branch name like "master", never
-  the tag). Fails closed if the resolved value isn't a valid vX.Y.Z tag.
-  Shared by aur-publish.yml's aur-source and aur-bin jobs.
+  Validates the version tag to publish (an explicit workflow_dispatch
+  input). Fails closed if it isn't a valid vX.Y.Z tag. Shared by
+  aur-publish.yml's aur-source and aur-bin jobs.
 
 inputs:
   input-tag:
-    description: The workflow_dispatch "tag" input, if any
-    required: false
-    default: ""
-  head-sha:
-    description: The triggering workflow_run's head_sha, if any
-    required: false
-    default: ""
-  repo:
-    description: "owner/repo to resolve tags against"
+    description: The workflow_dispatch "tag" input
     required: true
 
 outputs:
@@ -35,16 +25,8 @@ runs:
       shell: bash
       env:
         INPUT_TAG: ${{ inputs.input-tag }}
-        HEAD_SHA: ${{ inputs.head-sha }}
-        REPO: ${{ inputs.repo }}
       run: |
-        if [ -n "$INPUT_TAG" ]; then
-          TAG="$INPUT_TAG"
-        else
-          TAG=$(git ls-remote --tags "https://github.com/${REPO}.git" 'refs/tags/v*' \
-            | awk -v sha="$HEAD_SHA" \
-                '$1 == sha { gsub(/refs\/tags\//, "", $2); gsub(/\^\{\}$/, "", $2); if ($2 ~ /^v[0-9]/) { print $2; exit } }')
-        fi
+        TAG="$INPUT_TAG"
         if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
           echo "Invalid tag format: $TAG" >&2
           exit 1

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,29 +1,33 @@
 name: Publish to AUR
 
-# Triggered automatically after the Release workflow succeeds,
-# or manually via workflow_dispatch to re-publish an existing tag.
+# Triggered explicitly by the Release workflow's update-pkgbuild job once it
+# knows the tag being published (via `gh workflow run aur-publish.yml -f
+# tag=...`), or manually via workflow_dispatch to re-publish an existing tag.
+#
+# Not triggered by the implicit `workflow_run` event: for a manual
+# workflow_dispatch re-publish of Release, workflow_run.head_sha is just the
+# branch tip at dispatch time (not the tagged commit), so resolving the tag
+# by matching head_sha against remote tags fails for that case. Requiring an
+# explicit tag input sidesteps that entirely.
 #
 # Updates two AUR packages in parallel:
 #   susshi      — builds from the released source tarball
 #   susshi-bin  — installs the pre-built susshi-linux-x86_64 binary
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to re-publish (e.g. v0.12.0)"
+        description: "Tag to publish (e.g. v0.12.0)"
         required: true
 
 permissions:
   contents: read
 
-# A manual re-publish (workflow_dispatch) could otherwise race a run
-# triggered by the Release workflow completing for the same tag.
+# A manual re-publish could otherwise race the run triggered by release.yml
+# for the same tag.
 concurrency:
-  group: aur-publish-${{ github.event.inputs.tag || github.event.workflow_run.head_sha }}
+  group: aur-publish-${{ github.event.inputs.tag }}
   cancel-in-progress: false
 
 jobs:
@@ -36,16 +40,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-    # Also run when the completed Release workflow was itself a manual
-    # workflow_dispatch re-publish: a re-publish can rebuild the binary
-    # (overwrite: true on the upload step) with different bytes, which
-    # otherwise leaves the AUR package's checksum stale until the next
-    # tagged release.
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       (github.event.workflow_run.event == 'push' ||
-        github.event.workflow_run.event == 'workflow_dispatch'))
 
     steps:
       - name: Checkout
@@ -56,8 +50,6 @@ jobs:
         uses: ./.github/actions/resolve-release-tag
         with:
           input-tag: ${{ github.event.inputs.tag }}
-          head-sha: ${{ github.event.workflow_run.head_sha }}
-          repo: ${{ github.repository }}
 
       - name: Compute checksum of source archive
         id: checksum
@@ -105,16 +97,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-    # Also run when the completed Release workflow was itself a manual
-    # workflow_dispatch re-publish: a re-publish can rebuild the binary
-    # (overwrite: true on the upload step) with different bytes, which
-    # otherwise leaves the AUR package's checksum stale until the next
-    # tagged release.
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       (github.event.workflow_run.event == 'push' ||
-        github.event.workflow_run.event == 'workflow_dispatch'))
 
     steps:
       - name: Checkout
@@ -125,8 +107,6 @@ jobs:
         uses: ./.github/actions/resolve-release-tag
         with:
           input-tag: ${{ github.event.inputs.tag }}
-          head-sha: ${{ github.event.workflow_run.head_sha }}
-          repo: ${{ github.repository }}
 
       - name: Compute checksums (source archive + Linux binary)
         id: checksums

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ name: Release
 #   publish-rpm     — signs + publishes a DNF/YUM repo to gh-pages:/rpm (createrepo_c)
 #
 # After build:
-#   update-pkgbuild — commits refreshed PKGBUILD to master,
-#                     which triggers aur-publish.yml
+#   update-pkgbuild — commits refreshed PKGBUILD to master, then explicitly
+#                     triggers aur-publish.yml with the resolved tag
 
 on:
   push:
@@ -625,8 +625,7 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v7
         with:
-          # PAT required so this push triggers aur-publish.yml.
-          # GITHUB_TOKEN pushes are silently ignored by workflow event triggers.
+          # PAT required to push to master (branch-protected against GITHUB_TOKEN).
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ref: master
 
@@ -661,18 +660,24 @@ jobs:
             echo "No changes to commit"
             exit 0
           fi
-          TAG="${{ github.ref_name }}"
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           VERSION="${TAG#v}"
           git commit -m "chore(release): update PKGBUILD to v${VERSION}"
           git push
+
+      - name: Trigger AUR publish
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: gh workflow run aur-publish.yml --repo "${{ github.repository }}" -f tag="$TAG"
 
       - name: Notify on failure
         if: failure()
         uses: ./.github/actions/notify-failure
         with:
           github-token: ${{ github.token }}
-          title: "PKGBUILD update failed for ${{ github.ref_name }}"
-          body: "update-pkgbuild failed on release ${{ github.ref_name }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          title: "PKGBUILD update failed for ${{ github.event.inputs.tag || github.ref_name }}"
+          body: "update-pkgbuild failed on release ${{ github.event.inputs.tag || github.ref_name }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # ── Cleanup stale release-plz branches ───────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Fixes issues #177 and #178 (AUR publish failing with "Invalid tag format").
- Root cause: `update-pkgbuild`'s `TAG="${{ github.ref_name }}"` is correct for tag-push runs but resolves to the branch name (`master`) for a manual `workflow_dispatch` re-publish — hence the `chore(release): update PKGBUILD to vmaster` commit already on master. `aur-publish.yml`'s tag resolution then inherited the same class of bug: it inferred the tag from `workflow_run.head_sha`, which is the branch tip at dispatch time (not the tagged commit) for manual re-publishes, so no tag ever matched.
- Fix: `update-pkgbuild` now resolves the tag the same way every other job in `release.yml` already does (`github.event.inputs.tag || github.ref_name`), and explicitly triggers `aur-publish.yml` via `gh workflow run -f tag=...` instead of relying on the implicit `workflow_run` event + SHA guesswork. `resolve-release-tag` and `aur-publish.yml` are simplified accordingly (input tag is now always required, no fallback SHA matching).

## Test plan
- [x] All three edited workflow/action YAML files parse cleanly.
- [ ] Merge and confirm the next tag push produces a correct `chore(release): update PKGBUILD to vX.Y.Z` commit and a successful AUR publish.
- [ ] Manually re-run Release via `workflow_dispatch` with `tag=v0.21.0` to confirm `aur-publish.yml` now succeeds for a manual re-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7AveSzyY3HEsdx3qqreAP