### PR TITLE
fix: update proc-macro-error3 to unyanked v3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.0.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1250,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.0.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0d42490f6b7b143eef32b9e3522e42bf25dadc02c69ed72236f80adb949b5c"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",


### PR DESCRIPTION
## Summary
- `proc-macro-error3 v3.0.3` (a transitive dependency of `i18n-embed-impl`, pulled in via `i18n-embed`/`i18n-embed-fl`) was yanked from crates.io, which made the `cargo-deny` CI job fail with `error[yanked]: detected yanked crate`.
- Ran `cargo update -p proc-macro-error3` to move to `3.1.0`, the latest unyanked compatible version.

## Test plan
- [x] `cargo update -p proc-macro-error3` — locked to `3.1.0`
- [x] `cargo check` — builds cleanly
- [ ] CI `Security (cargo deny)` job passes